### PR TITLE
impl FromLua for serde_json::Value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ module = ["mlua_derive", "ffi/module"]
 async = ["futures-util"]
 send = []
 serialize = ["serde", "erased-serde", "serde-value"]
+json = ["serialize", "serde_json"]
 macros = ["mlua_derive/macros"]
 unstable = []
 
@@ -51,6 +52,7 @@ num-traits = { version = "0.2.14" }
 rustc-hash = "1.0"
 futures-util = { version = "0.3", optional = true, default-features = false, features = ["std"] }
 serde = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true }
 erased-serde = { version = "0.3", optional = true }
 serde-value = { version = "0.7", optional = true }
 parking_lot = { version = "0.12", optional = true }

--- a/src/value.rs
+++ b/src/value.rs
@@ -628,6 +628,18 @@ pub trait FromLuaMulti<'lua>: Sized {
     }
 }
 
+#[cfg(feature = "json")]
+impl<'lua> FromLua<'lua> for serde_json::Value {
+    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Self> {
+        let ty = value.type_name();
+        serde_json::to_value(value).map_err(|e| Error::FromLuaConversionError {
+            from: ty,
+            to: "serde_json::Value",
+            message: Some(format!("{}", e)),
+        })
+    }
+}
+
 #[cfg(test)]
 mod assertions {
     use super::*;


### PR DESCRIPTION
This pull request introduces the implementation of the `FromLua` trait for `serde_json::Value`. This will allow smooth conversion from Lua values to serde_json values and get rid of the `'lua` lifetime, providing better integration and flexibility.

**Details**:

1. **Added a new feature flag for json**:
   A new feature flag named `json` has been added, dependent on both the `serialize` feature and the `serde_json` crate. This allows the conditional compilation of the new implementation, ensuring backward compatibility.

2. **Updated Cargo.toml**:
   - Added `serde_json` as an optional dependency, with version `"1.0"`.

3. **Updated src/value.rs**:
   - Added an implementation block for `FromLua` trait for `serde_json::Value`.
   - Inside the `from_lua` method, a value of Lua type is converted to a `serde_json::Value`, handling any potential conversion errors and wrapping them into the `Error::FromLuaConversionError`.