### PR TITLE
Add `Lua::(reset_)num_allocations` API

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -42,11 +42,11 @@ pub enum Error {
     GarbageCollectorError(StdString),
     /// Potentially unsafe action in safe mode.
     SafetyError(StdString),
-    /// Setting memory limit is not available.
+    /// Setting memory limit or getting/resetting the number of allocation is not available.
     ///
     /// This error can only happen when Lua state was not created by us and does not have the
     /// custom allocator attached.
-    MemoryLimitNotAvailable,
+    MemoryStatsNotAvailable,
     /// A mutable callback has triggered Lua code that has called the same mutable callback again.
     ///
     /// This is an error because a mutable callback can only be borrowed mutably once.
@@ -218,7 +218,7 @@ impl fmt::Display for Error {
             Error::SafetyError(ref msg) => {
                 write!(fmt, "safety error: {msg}")
             },
-            Error::MemoryLimitNotAvailable => {
+            Error::MemoryStatsNotAvailable => {
                 write!(fmt, "setting memory limit is not available")
             }
             Error::RecursiveMutCallback => write!(fmt, "mutable callback called recursively"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -219,7 +219,7 @@ impl fmt::Display for Error {
                 write!(fmt, "safety error: {msg}")
             },
             Error::MemoryStatsNotAvailable => {
-                write!(fmt, "setting memory limit is not available")
+                write!(fmt, "memory stats information is not available")
             }
             Error::RecursiveMutCallback => write!(fmt, "mutable callback called recursively"),
             Error::CallbackDestructed => write!(

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -1121,7 +1121,7 @@ impl Lua {
         unsafe {
             match (*self.extra.get()).mem_state.map(|mut x| x.as_mut()) {
                 Some(mem_state) => Ok(mem_state.set_memory_limit(limit)),
-                None => Err(Error::MemoryLimitNotAvailable),
+                None => Err(Error::MemoryStatsNotAvailable),
             }
         }
     }

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -1126,6 +1126,36 @@ impl Lua {
         }
     }
 
+    /// Returns the count of memory allocations invoked by this Lua runtime.
+    ///
+    /// Note that in case of overflow, the counter resets to zero(simply speaking, it 'wraps'),
+    /// and the overflowing threshold above the maximum depends on the platform.
+    ///
+    /// Returns [`Error::MemoryStatsNotAvailable`] if Lua state is managed externally.
+    pub fn num_allocations(&self) -> Result<usize> {
+        unsafe {
+            match (*self.extra.get()).mem_state.map(|x| x.as_ref()) {
+                Some(mem_state) => Ok(mem_state.num_allocations()),
+                None => Err(Error::MemoryStatsNotAvailable),
+            }
+        }
+    }
+
+    /// Resets the count of memory allocations to zero.
+    ///
+    /// Returns [`Error::MemoryStatsNotAvailable`] if Lua state is managed externally.
+    pub fn reset_num_allocations(&self) -> Result<()> {
+        unsafe {
+            match (*self.extra.get()).mem_state.map(|mut x| x.as_mut()) {
+                Some(mem_state) => {
+                    mem_state.reset_num_allocations();
+                    Ok(())
+                }
+                None => Err(Error::MemoryStatsNotAvailable),
+            }
+        }
+    }
+
     /// Returns true if the garbage collector is currently running automatically.
     ///
     /// Requires `feature = "lua54/lua53/lua52/luau"`


### PR DESCRIPTION
I was in need to track the number of memory allocations, so added an API to support this.

- `Lua::num_allocations` simply returns a number of allocations invoked by Lua runtime since the runtime has been created.
- `Lua::reset_num_allocations` resets the counter.