### PR TITLE
Make Compiler::compile more idiomatic (breaking)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlua"
-version = "0.9.6" # remember to update mlua_derive
+version = "0.10.0" # remember to update mlua_derive
 authors = ["Aleksandr Orlenko <zxteam@pm.me>", "kyren <catherine@kyju.org>"]
 rust-version = "1.71"
 edition = "2021"

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -4,7 +4,7 @@ use std::{
     ffi::CString,
     io::Result as IoResult,
     path::{Path, PathBuf},
-    string::String as StdString
+    string::String as StdString,
 };
 
 use crate::{
@@ -12,7 +12,7 @@ use crate::{
     function::Function,
     lua::Lua,
     table::Table,
-    value::{FromLuaMulti, IntoLua, IntoLuaMulti}
+    value::{FromLuaMulti, IntoLua, IntoLuaMulti},
 };
 
 /// Trait for types [loadable by Lua] and convertible to a [`Chunk`]
@@ -223,7 +223,7 @@ impl Compiler {
     }
 
     /// Compiles the `source` into bytecode.
-    /// 
+    ///
     /// # Errors
     /// Returns an error if compilation of the source code fails.
     pub fn compile(&self, source: impl AsRef<[u8]>) -> Result<Vec<u8>> {
@@ -442,7 +442,7 @@ impl<'lua, 'a> Chunk<'lua, 'a> {
     /// Compiles the chunk and changes mode to binary.
     ///
     /// It does nothing if the chunk is already binary.
-    /// 
+    ///
     /// # Errors
     /// Errors if a Luau chunk fails to compile. See [`Compiler::compile`].
     fn compile(&mut self) -> Result<()> {
@@ -470,7 +470,7 @@ impl<'lua, 'a> Chunk<'lua, 'a> {
 
     /// Fetches compiled bytecode of this chunk from the cache.
     /// If not found, compiles the source code and stores it on the cache.
-    /// 
+    ///
     /// # Errors
     /// Errors if Luau is targeted and compilation of the source code fails.
     pub(crate) fn try_cache(mut self) -> Result<Self> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -323,6 +323,7 @@ impl fmt::Display for Error {
                 writeln!(fmt, "{context}")?;
                 write!(fmt, "{cause}")
             },
+            #[cfg(feature = "luau")]
             Error::CompileError { line, ref message} => {
                 writeln!(fmt, "luau compilation error on line {line}: {message}")
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -200,11 +200,11 @@ pub enum Error {
     #[cfg(any(feature = "luau", doc))]
     #[cfg_attr(docsrs, doc(cfg(feature = "luau")))]
     /// Luau compilation error.
-    CompileError { 
+    CompileError {
         /// The line on which the error occurred.
         line: usize,
         /// The error message as returned by Luau.
-        message: String
+        message: String,
     },
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -197,6 +197,15 @@ pub enum Error {
         /// Underlying error.
         cause: Arc<Error>,
     },
+    #[cfg(any(feature = "luau", doc))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "luau")))]
+    /// Luau compilation error.
+    CompileError { 
+        /// The line on which the error occurred.
+        line: usize,
+        /// The error message as returned by Luau.
+        message: String
+    },
 }
 
 /// A specialized `Result` type used by `mlua`'s API.
@@ -313,6 +322,9 @@ impl fmt::Display for Error {
             Error::WithContext { ref context, ref cause } => {
                 writeln!(fmt, "{context}")?;
                 write!(fmt, "{cause}")
+            },
+            Error::CompileError { line, ref message} => {
+                writeln!(fmt, "luau compilation error on line {line}: {message}")
             }
         }
     }

--- a/src/function.rs
+++ b/src/function.rs
@@ -270,7 +270,7 @@ impl<'lua> Function<'lua> {
             end
             "#,
         )
-        .try_cache()
+        .try_cache()?
         .set_name("__mlua_bind")
         .call((self.clone(), args_wrapper))
     }

--- a/src/function.rs
+++ b/src/function.rs
@@ -344,7 +344,7 @@ impl<'lua> Function<'lua> {
                         let f_with_env = lua
                             .load("return _ENV")
                             .set_environment(env)
-                            .try_cache()
+                            .try_cache()?
                             .into_function()?;
                         lua.push_ref(&f_with_env.0);
                         ffi::lua_upvaluejoin(state, -2, i, -1, 1);

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -3047,7 +3047,7 @@ impl Lua {
             end
             "#,
         )
-        .try_cache()
+        .try_cache()?
         .set_name("__mlua_async_poll")
         .set_environment(env)
         .into_function()

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -177,7 +177,7 @@ fn test_load_mode() -> Result<()> {
         // Test that compilation doesn't work when it shouldn't
         // Also! Using stringify! for lua chunks works without a hitch and gives basic syntax highlighting! It's great.
         static INCORRECT_CODE: &str = stringify! {
-            print({}.1)
+            print({1}.1)
         };
         match mlua::Compiler::new().compile(INCORRECT_CODE) {
             Ok(_) => panic!("failed to reject incorrect Luau code"),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -156,7 +156,9 @@ fn test_load_mode() -> Result<()> {
     #[cfg(not(feature = "luau"))]
     let bytecode = lua.load("return 1 + 1").into_function()?.dump(true);
     #[cfg(feature = "luau")]
-    let bytecode = mlua::Compiler::new().compile("return 1 + 1").expect("trivial compilation failed");
+    let bytecode = mlua::Compiler::new()
+        .compile("return 1 + 1")
+        .expect("trivial compilation failed");
     assert_eq!(lua.load(&bytecode).eval::<i32>()?, 2);
     assert_eq!(
         lua.load(&bytecode)
@@ -182,7 +184,10 @@ fn test_load_mode() -> Result<()> {
         match mlua::Compiler::new().compile(INCORRECT_CODE) {
             Ok(_) => panic!("failed to reject incorrect Luau code"),
             Err(err @ Error::CompileError { .. }) => eprintln!("{err}"),
-            Err(ref e) => panic!("incorrect error {} for failure to compile Luau code", std::any::type_name_of_val(e))
+            Err(ref e) => panic!(
+                "incorrect error {} for failure to compile Luau code",
+                std::any::type_name_of_val(e)
+            ),
         }
     }
 


### PR DESCRIPTION
This changes the type signature of `Compiler::compile` from a `Vec<u8>` to a `Result<Vec<u8>>`, properly handling the error case. This is a breaking change.