### PR TITLE
update build.rs to fix cross compilation of windows dlls from unix

### DIFF
--- a/mlua-sys/build/main_inner.rs
+++ b/mlua-sys/build/main_inner.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 cfg_if::cfg_if! {
     if #[cfg(any(feature = "luau", feature = "vendored"))] {
         #[path = "find_vendored.rs"]
@@ -17,8 +19,8 @@ fn main() {
 
     println!("cargo:rerun-if-changed=build");
 
-    #[cfg(windows)]
-    if cfg!(feature = "module") {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    if target_os == "windows" && cfg!(feature = "module") {
         if !std::env::var("LUA_LIB_NAME").unwrap_or_default().is_empty() {
             // Don't use raw-dylib linking
             find::probe_lua();


### PR DESCRIPTION
Hi, I realize it might seem like a crazy thing to want to do on the face of it, however when building mods for windows games that run under wine, it turns out you need to generate a PE dll quite often.

I have tested that modules continue to build correctly on windows and also with --target=x86_64-pc-windows-gnu on linux. Either configuration produces a working DLL that can be loaded and used by a windows game running under either windows or wine.
