### PR TITLE
Make `LightUserData` support Send/Sync

### DIFF
--- a/src/lua.rs
+++ b/src/lua.rs
@@ -3013,7 +3013,7 @@ impl Lua {
                 match fut.as_mut().poll(&mut ctx) {
                     Poll::Pending => {
                         ffi::lua_pushnil(state);
-                        ffi::lua_pushlightuserdata(state, Lua::poll_pending().0);
+                        ffi::lua_pushlightuserdata(state, Lua::poll_pending().as_ptr());
                         Ok(2)
                     }
                     Poll::Ready(nresults) => {
@@ -3121,7 +3121,7 @@ impl Lua {
     #[doc(hidden)]
     #[inline]
     pub fn poll_pending() -> LightUserData {
-        LightUserData(&ASYNC_POLL_PENDING as *const u8 as *mut c_void)
+        LightUserData::new(&ASYNC_POLL_PENDING as *const u8 as *mut c_void)
     }
 
     pub(crate) unsafe fn make_userdata<T>(&self, data: UserDataCell<T>) -> Result<AnyUserData>

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -2349,7 +2349,7 @@ impl Lua {
         match value {
             Value::Nil => ffi::lua_pushnil(state),
             Value::Boolean(b) => ffi::lua_pushboolean(state, *b as c_int),
-            Value::LightUserData(ud) => ffi::lua_pushlightuserdata(state, ud.0),
+            Value::LightUserData(ud) => ffi::lua_pushlightuserdata(state, ud.as_ptr()),
             Value::Integer(i) => ffi::lua_pushinteger(state, *i),
             Value::Number(n) => ffi::lua_pushnumber(state, *n),
             #[cfg(feature = "luau")]
@@ -2391,7 +2391,7 @@ impl Lua {
             }
 
             ffi::LUA_TLIGHTUSERDATA => {
-                let ud = Value::LightUserData(LightUserData(ffi::lua_touserdata(state, -1)));
+                let ud = Value::LightUserData(LightUserData::new(ffi::lua_touserdata(state, -1)));
                 ffi::lua_pop(state, 1);
                 ud
             }
@@ -2493,7 +2493,7 @@ impl Lua {
             ffi::LUA_TBOOLEAN => Value::Boolean(ffi::lua_toboolean(state, idx) != 0),
 
             ffi::LUA_TLIGHTUSERDATA => {
-                Value::LightUserData(LightUserData(ffi::lua_touserdata(state, idx)))
+                Value::LightUserData(LightUserData::new(ffi::lua_touserdata(state, idx)))
             }
 
             #[cfg(any(feature = "lua54", feature = "lua53"))]

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -540,7 +540,7 @@ where
 #[cfg(feature = "async")]
 #[inline(always)]
 unsafe fn is_poll_pending(state: *mut ffi::lua_State) -> bool {
-    ffi::lua_tolightuserdata(state, -1) == Lua::poll_pending().0
+    ffi::lua_tolightuserdata(state, -1) == Lua::poll_pending().as_ptr()
 }
 
 #[cfg(feature = "async")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -41,7 +41,25 @@ pub(crate) enum SubtypeId {
 
 /// A "light" userdata value. Equivalent to an unmanaged raw pointer.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct LightUserData(pub *mut c_void);
+pub struct LightUserData(usize);
+
+impl LightUserData {
+    pub fn new(ptr: *mut c_void) -> Self {
+        LightUserData(ptr as usize)
+    }
+
+    pub const fn null_ptr() -> Self {
+        LightUserData(0)
+    }
+
+    pub fn as_ptr(&self) -> *mut c_void {
+        self.0 as *mut c_void
+    }
+
+    pub fn is_null(&self) -> bool {
+        self.as_ptr().is_null()
+    }
+}
 
 pub(crate) type Callback<'lua, 'a> = Box<dyn Fn(&'lua Lua, c_int) -> Result<c_int> + 'a>;
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -72,7 +72,7 @@ impl<'lua> Value<'lua> {
     /// A special value (lightuserdata) to represent null value.
     ///
     /// It can be used in Lua tables without downsides of `nil`.
-    pub const NULL: Value<'static> = Value::LightUserData(LightUserData(ptr::null_mut()));
+    pub const NULL: Value<'static> = Value::LightUserData(LightUserData::null_ptr());
 
     /// Returns type name of this value.
     pub const fn type_name(&self) -> &'static str {
@@ -125,7 +125,7 @@ impl<'lua> Value<'lua> {
     #[inline]
     pub fn to_pointer(&self) -> *const c_void {
         match self {
-            Value::LightUserData(ud) => ud.0,
+            Value::LightUserData(ud) => ud.as_ptr(),
             Value::String(String(r))
             | Value::Table(Table(r))
             | Value::Function(Function(r))
@@ -142,8 +142,8 @@ impl<'lua> Value<'lua> {
         match self {
             Value::Nil => Ok("nil".to_string()),
             Value::Boolean(b) => Ok(b.to_string()),
-            Value::LightUserData(ud) if ud.0.is_null() => Ok("null".to_string()),
-            Value::LightUserData(ud) => Ok(format!("lightuserdata: {:p}", ud.0)),
+            Value::LightUserData(ud) if ud.is_null() => Ok("null".to_string()),
+            Value::LightUserData(ud) => Ok(format!("lightuserdata: {:p}", ud.as_ptr())),
             Value::Integer(i) => Ok(i.to_string()),
             Value::Number(n) => Ok(n.to_string()),
             #[cfg(feature = "luau")]
@@ -463,8 +463,8 @@ impl<'lua> Value<'lua> {
             (_, Value::Nil) => Ordering::Greater,
             // Null (a special case)
             (Value::LightUserData(ud1), Value::LightUserData(ud2)) if ud1 == ud2 => Ordering::Equal,
-            (Value::LightUserData(ud1), _) if ud1.0.is_null() => Ordering::Less,
-            (_, Value::LightUserData(ud2)) if ud2.0.is_null() => Ordering::Greater,
+            (Value::LightUserData(ud1), _) if ud1.is_null() => Ordering::Less,
+            (_, Value::LightUserData(ud2)) if ud2.is_null() => Ordering::Greater,
             // Boolean
             (Value::Boolean(a), Value::Boolean(b)) => a.cmp(b),
             (Value::Boolean(_), _) => Ordering::Less,
@@ -495,8 +495,8 @@ impl<'lua> Value<'lua> {
         match self {
             Value::Nil => write!(fmt, "nil"),
             Value::Boolean(b) => write!(fmt, "{b}"),
-            Value::LightUserData(ud) if ud.0.is_null() => write!(fmt, "null"),
-            Value::LightUserData(ud) => write!(fmt, "lightuserdata: {:?}", ud.0),
+            Value::LightUserData(ud) if ud.is_null() => write!(fmt, "null"),
+            Value::LightUserData(ud) => write!(fmt, "lightuserdata: {:?}", ud.as_ptr()),
             Value::Integer(i) => write!(fmt, "{i}"),
             Value::Number(n) => write!(fmt, "{n}"),
             #[cfg(feature = "luau")]


### PR DESCRIPTION
The user pointer will not change, and we'll use internal variables that are not exposed.

The user pointer can be stored using the `usize` type, which supports `Send` and `Sync`.

Fixed issue #413