### PR TITLE
Added a ToLua derive macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ module = ["dep:mlua_derive", "ffi/module"]
 async = ["dep:futures-util"]
 send = []
 serialize = ["dep:serde", "dep:erased-serde", "dep:serde-value"]
+uuid = ["dep:uuid", "dep:serde"]
 macros = ["mlua_derive/macros"]
 unstable = []
 
@@ -51,6 +52,7 @@ num-traits = { version = "0.2.14" }
 rustc-hash = "2.0"
 futures-util = { version = "0.3", optional = true, default-features = false, features = ["std"] }
 serde = { version = "1.0", optional = true }
+uuid = { version = "1.10.0", optional = true, features = ["v7", "serde"]}
 erased-serde = { version = "0.4", optional = true }
 serde-value = { version = "0.7", optional = true }
 parking_lot = { version = "0.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ async = ["dep:futures-util"]
 send = []
 serialize = ["dep:serde", "dep:erased-serde", "dep:serde-value"]
 uuid = ["dep:uuid", "dep:serde"]
+time = ["dep:time"]
+json = ["serialize", "serde_json"]
 macros = ["mlua_derive/macros"]
 unstable = []
 
@@ -52,9 +54,11 @@ num-traits = { version = "0.2.14" }
 rustc-hash = "2.0"
 futures-util = { version = "0.3", optional = true, default-features = false, features = ["std"] }
 serde = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true}
 uuid = { version = "1.10.0", optional = true, features = ["v7", "serde"]}
 erased-serde = { version = "0.4", optional = true }
 serde-value = { version = "0.7", optional = true }
+time = {version = "0.3.36", optional = true, features = ["parsing"]}
 parking_lot = { version = "0.12", optional = true }
 
 ffi = { package = "mlua-sys", version = "0.6.1", path = "mlua-sys" }

--- a/mlua_derive/src/from_lua_table.rs
+++ b/mlua_derive/src/from_lua_table.rs
@@ -1,0 +1,45 @@
+use proc_macro::TokenStream;
+use quote::{quote, format_ident};
+use syn::{parse_macro_input, DeriveInput, Data, Fields};
+
+pub fn from_lua_table(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let ident = input.ident;
+
+    let fields = if let Data::Struct(data_struct) = input.data {
+        match data_struct.fields {
+            Fields::Named(fields) => fields,
+            _ => panic!("FromLuaTable can only be derived for structs with named fields"),
+        }
+    } else {
+        panic!("FromLuaTable can only be derived for structs");
+    };
+
+    let get_fields = fields.named.iter().map(|field| {
+        let name = &field.ident;
+        let name_str = name.as_ref().unwrap().to_string();
+        quote! {
+            #name: table.get(#name_str)?,
+        }
+    });
+
+    let gen = quote! {
+        impl<'lua> ::mlua::FromLua<'lua> for #ident {
+            fn from_lua(lua_value: ::mlua::Value<'lua>, lua: &'lua ::mlua::Lua) -> ::mlua::Result<Self> {
+                if let ::mlua::Value::Table(table) = lua_value {
+                    Ok(Self {
+                        #(#get_fields)*
+                    })
+                } else {
+                    Err(::mlua::Error::FromLuaConversionError {
+                        from: lua_value.type_name(),
+                        to: stringify!(#ident),
+                        message: Some(String::from("expected a Lua table")),
+                    })
+                }
+            }
+        }
+    };
+
+    gen.into()
+}

--- a/mlua_derive/src/lib.rs
+++ b/mlua_derive/src/lib.rs
@@ -160,10 +160,26 @@ pub fn to_lua(input: TokenStream) -> TokenStream {
 }
 
 #[cfg(feature = "macros")]
+#[proc_macro_derive(FromLuaTable)]
+pub fn from_lua_table(input: TokenStream) -> TokenStream {
+    from_lua_table::from_lua_table(input)
+}
+
+#[cfg(feature = "macros")]
+#[proc_macro_derive(ToLuaTable)]
+pub fn to_lua_table(input: TokenStream) -> TokenStream {
+    to_lua_table::to_lua_table(input)
+}
+
+#[cfg(feature = "macros")]
 mod chunk;
 #[cfg(feature = "macros")]
 mod from_lua;
 #[cfg(feature = "macros")]
 mod to_lua;
+#[cfg(feature = "macros")]
+mod from_lua_table;
+#[cfg(feature = "macros")]
+mod to_lua_table;
 #[cfg(feature = "macros")]
 mod token;

--- a/mlua_derive/src/lib.rs
+++ b/mlua_derive/src/lib.rs
@@ -154,8 +154,16 @@ pub fn from_lua(input: TokenStream) -> TokenStream {
 }
 
 #[cfg(feature = "macros")]
+#[proc_macro_derive(ToLua)]
+pub fn to_lua(input: TokenStream) -> TokenStream {
+    to_lua::to_lua(input)
+}
+
+#[cfg(feature = "macros")]
 mod chunk;
 #[cfg(feature = "macros")]
 mod from_lua;
+#[cfg(feature = "macros")]
+mod to_lua;
 #[cfg(feature = "macros")]
 mod token;

--- a/mlua_derive/src/to_lua.rs
+++ b/mlua_derive/src/to_lua.rs
@@ -1,6 +1,9 @@
 use proc_macro::TokenStream;
 use quote::{quote, format_ident};
-use syn::{parse_macro_input, DeriveInput, Data, Fields};
+use syn::{parse_macro_input, DeriveInput, Data, Fields, Type};
+use syn::spanned::Spanned;
+use syn::punctuated::Punctuated;
+use proc_macro2::TokenStream as TokenStream2;
 
 pub fn to_lua(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -15,23 +18,60 @@ pub fn to_lua(input: TokenStream) -> TokenStream {
         panic!("ToLua can only be derived for structs");
     };
 
-    let set_fields = fields.named.iter().map(|field| {
+    let add_field_methods = fields.named.iter().map(|field| {
         let name = &field.ident;
         let name_str = name.as_ref().unwrap().to_string();
+        let ty = &field.ty;
+
+        let get_method = if is_copy_type(ty) {
+            quote! {
+                fields.add_field_method_get(#name_str, |_, this| Ok(this.#name));
+            }
+        } else {
+            quote! {
+                fields.add_field_method_get(#name_str, |_, this| Ok(this.#name.clone()));
+            }
+        };
+
+        let set_method = quote! {
+            fields.add_field_method_set(#name_str, |_, this, val| {
+                this.#name = val;
+                Ok(())
+            });
+        };
+
         quote! {
-            table.set(#name_str, self.#name)?;
+            #get_method
+            #set_method
         }
     });
 
     let gen = quote! {
-        impl<'lua> ::mlua::IntoLua<'lua> for #ident {
-            fn into_lua(self, lua: &'lua ::mlua::Lua) -> ::mlua::Result<::mlua::Value<'lua>> {
-                let table = lua.create_table()?;
-                #(#set_fields)*
-                Ok(::mlua::Value::Table(table))
+        impl ::mlua::UserData for #ident {
+            fn add_fields<'lua, F: ::mlua::prelude::LuaUserDataFields<'lua, Self>>(fields: &mut F) {
+                #(#add_field_methods)*
             }
         }
     };
 
     gen.into()
+}
+
+// I don't know how to determine whether or not something implements copy, so for now everything
+// will be cloned that isn't one of these copyable primitives.
+fn is_copy_type(ty: &Type) -> bool {
+    match ty {
+        Type::Path(type_path) => {
+            let segments = &type_path.path.segments;
+            let segment = segments.last().unwrap();
+            match segment.ident.to_string().as_str() {
+                "u8" | "u16" | "u32" | "u64" | "u128" |
+                "i8" | "i16" | "i32" | "i64" | "i128" |
+                "f32" | "f64" |
+                "bool" | "char" | "usize" | "isize" => true,
+                _ => false,
+            }
+        }
+        _ => false,
+    }
 }

--- a/mlua_derive/src/to_lua.rs
+++ b/mlua_derive/src/to_lua.rs
@@ -1,0 +1,37 @@
+use proc_macro::TokenStream;
+use quote::{quote, format_ident};
+use syn::{parse_macro_input, DeriveInput, Data, Fields};
+
+pub fn to_lua(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let ident = input.ident;
+
+    let fields = if let Data::Struct(data_struct) = input.data {
+        match data_struct.fields {
+            Fields::Named(fields) => fields,
+            _ => panic!("ToLua can only be derived for structs with named fields"),
+        }
+    } else {
+        panic!("ToLua can only be derived for structs");
+    };
+
+    let set_fields = fields.named.iter().map(|field| {
+        let name = &field.ident;
+        let name_str = name.as_ref().unwrap().to_string();
+        quote! {
+            table.set(#name_str, self.#name)?;
+        }
+    });
+
+    let gen = quote! {
+        impl<'lua> ::mlua::IntoLua<'lua> for #ident {
+            fn into_lua(self, lua: &'lua ::mlua::Lua) -> ::mlua::Result<::mlua::Value<'lua>> {
+                let table = lua.create_table()?;
+                #(#set_fields)*
+                Ok(::mlua::Value::Table(table))
+            }
+        }
+    };
+
+    gen.into()
+}

--- a/mlua_derive/src/to_lua_table.rs
+++ b/mlua_derive/src/to_lua_table.rs
@@ -1,0 +1,37 @@
+use proc_macro::TokenStream;
+use quote::{quote, format_ident};
+use syn::{parse_macro_input, DeriveInput, Data, Fields};
+
+pub fn to_lua_table(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let ident = input.ident;
+
+    let fields = if let Data::Struct(data_struct) = input.data {
+        match data_struct.fields {
+            Fields::Named(fields) => fields,
+            _ => panic!("ToLua can only be derived for structs with named fields"),
+        }
+    } else {
+        panic!("ToLua can only be derived for structs");
+    };
+
+    let set_fields = fields.named.iter().map(|field| {
+        let name = &field.ident;
+        let name_str = name.as_ref().unwrap().to_string();
+        quote! {
+            table.set(#name_str, self.#name)?;
+        }
+    });
+
+    let gen = quote! {
+        impl<'lua> ::mlua::IntoLua<'lua> for #ident {
+            fn into_lua(self, lua: &'lua ::mlua::Lua) -> ::mlua::Result<::mlua::Value<'lua>> {
+                let table = lua.create_table()?;
+                #(#set_fields)*
+                Ok(::mlua::Value::Table(table))
+            }
+        }
+    };
+
+    gen.into()
+}

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -521,19 +521,19 @@ impl<'lua> FromLua<'lua> for LightUserData {
 }
 
 //#[cfg(feature = "uuid")]
-impl<'lua> FromLua<'lua> for uuid::Uuid<'lua> {
+impl<'lua> FromLua<'lua> for uuid::Uuid {
     #[inline]
-    fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<uuid::Uuid<'lua>> {
+    fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<uuid::Uuid> {
         let ty = value.type_name();
         let string_result = lua.coerce_string(value)?
             .ok_or_else(|| Error::FromLuaConversionError {
                 from: ty,
                 to: "string",
-                message: Some("expected string or number".to_string()),
+                message: Some("expected string uuid".to_string()),
             });
         match string_result {
             Ok(string) => {
-                Ok(Uuid::parse_str(string.as_str()))
+                Ok(Uuid::parse_str(string.to_str()))
             },
             Err(e) => Err(e)
         }
@@ -541,7 +541,7 @@ impl<'lua> FromLua<'lua> for uuid::Uuid<'lua> {
 }
 
 //#[cfg(feature = "uuid")]
-impl<'lua> IntoLua<'lua> for uuid::Uuid<'lua> {
+impl<'lua> IntoLua<'lua> for uuid::Uuid {
     #[inline]
     fn into_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
         Ok(Value::String(self.to_string()))
@@ -549,7 +549,7 @@ impl<'lua> IntoLua<'lua> for uuid::Uuid<'lua> {
 }
 
 //#[cfg(feature = "uuid")]
-impl<'lua> IntoLua<'lua> for &uuid::Uuid<'lua> {
+impl<'lua> IntoLua<'lua> for &uuid::Uuid {
     #[inline]
     fn into_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
         Ok(Value::String(self.clone().to_string()))

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -535,7 +535,7 @@ impl<'lua> FromLua<'lua> for uuid::Uuid {
             Ok(string) => {
                 match uuid::Uuid::parse_str(string.to_str()?) {
                     Ok(val) => Ok(val),
-                    Err(e) => Err(e.into())
+                    Err(_) => Err(())
                 }
             },
             Err(e) => Err(e)

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -533,7 +533,7 @@ impl<'lua> FromLua<'lua> for uuid::Uuid {
             });
         match string_result {
             Ok(string) => {
-                Ok(uuid::Uuid::parse_str(string.to_str()?))
+                Ok(uuid::Uuid::parse_str(string.to_str()?)?)
             },
             Err(e) => Err(e)
         }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -521,28 +521,6 @@ impl<'lua> FromLua<'lua> for LightUserData {
 }
 
 //#[cfg(feature = "uuid")]
-impl<'lua> IntoLua<'lua> for uuid::Uuid {
-    #[inline]
-    fn into_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
-        Ok(Value::String(self.to_string()))
-    }
-}
-
-//#[cfg(feature = "uuid")]
-impl<'lua> IntoLua<'lua> for &uuid::Uuid {
-    #[inline]
-    fn into_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
-        Ok(Value::String(self.clone().to_string()))
-    }
-
-    #[inline]
-    unsafe fn push_into_stack(self, lua: &'lua Lua) -> Result<()> {
-        lua.push_ref(&self.to_string().0);
-        Ok(())
-    }   
-}
-
-//#[cfg(feature = "uuid")]
 impl<'lua> FromLua<'lua> for uuid::Uuid<'lua> {
     #[inline]
     fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<uuid::Uuid<'lua>> {
@@ -561,6 +539,56 @@ impl<'lua> FromLua<'lua> for uuid::Uuid<'lua> {
         }
     }
 }
+
+//#[cfg(feature = "uuid")]
+impl<'lua> IntoLua<'lua> for uuid::Uuid<'lua> {
+    #[inline]
+    fn into_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+        Ok(Value::String(self.to_string()))
+    }
+}
+
+//#[cfg(feature = "uuid")]
+impl<'lua> IntoLua<'lua> for &uuid::Uuid<'lua> {
+    #[inline]
+    fn into_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+        Ok(Value::String(self.clone().to_string()))
+    }
+
+    #[inline]
+    unsafe fn push_into_stack(self, lua: &'lua Lua) -> Result<()> {
+        lua.push_ref(&self.0);
+        Ok(())
+    }   
+}
+
+
+// impl<'lua> FromLua<'lua> for Value<'lua> {
+//     #[inline]
+//     fn from_lua(lua_value: Value<'lua>, _: &'lua Lua) -> Result<Self> {
+//         Ok(lua_value)
+//     }
+// }
+
+// impl<'lua> IntoLua<'lua> for String<'lua> {
+//     #[inline]
+//     fn into_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+//         Ok(Value::String(self))
+//     }
+// }
+
+// impl<'lua> IntoLua<'lua> for &String<'lua> {
+//     #[inline]
+//     fn into_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+//         Ok(Value::String(self.clone()))
+//     }
+
+//     #[inline]
+//     unsafe fn push_into_stack(self, lua: &'lua Lua) -> Result<()> {
+//         lua.push_ref(&self.0);
+//         Ok(())
+//     }
+// }
 
 
 #[cfg(feature = "luau")]

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -535,7 +535,7 @@ impl<'lua> FromLua<'lua> for uuid::Uuid {
             Ok(string) => {
                 match uuid::Uuid::parse_str(string.to_str()?) {
                     Ok(val) => Ok(val),
-                    Err(e) => Err(e)
+                    Err(e) => Err(e.into())
                 }
             },
             Err(e) => Err(e)

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -535,7 +535,11 @@ impl<'lua> FromLua<'lua> for uuid::Uuid {
             Ok(string) => {
                 match uuid::Uuid::parse_str(string.to_str()?) {
                     Ok(val) => Ok(val),
-                    Err(_) => Err(())
+                    Err(_) => Err(Error::FromLuaConversionError {
+                        from: "string",
+                        to: "uuid::Uuid",
+                        message: Some("failed to parse UUID".to_string()),
+                    })
                 }
             },
             Err(e) => Err(e)

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -533,7 +533,7 @@ impl<'lua> FromLua<'lua> for uuid::Uuid {
             });
         match string_result {
             Ok(string) => {
-                Ok(Uuid::parse_str(string.to_str()))
+                Ok(uuid::Uuid::parse_str(string.to_str()))
             },
             Err(e) => Err(e)
         }
@@ -552,7 +552,7 @@ impl<'lua> IntoLua<'lua> for uuid::Uuid {
 //#[cfg(feature = "uuid")]
 impl<'lua> IntoLua<'lua> for &uuid::Uuid {
     #[inline]
-    fn into_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+    fn into_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
         let uuid_string = lua.create_string(self.to_string().as_str())?;
         Ok(Value::String(uuid_string))
     }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -543,8 +543,8 @@ impl<'lua> FromLua<'lua> for uuid::Uuid {
 //#[cfg(feature = "uuid")]
 impl<'lua> IntoLua<'lua> for uuid::Uuid {
     #[inline]
-    fn into_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
-        let uuid_string: String<'lua> = self.to_string();
+    fn into_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+        let uuid_string = lua.create_string(self.to_string().as_str())?;
         Ok(Value::String(uuid_string))
     }
 }
@@ -553,13 +553,14 @@ impl<'lua> IntoLua<'lua> for uuid::Uuid {
 impl<'lua> IntoLua<'lua> for &uuid::Uuid {
     #[inline]
     fn into_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
-        let uuid_string: String<'lua> = self.clone().to_string();
+        let uuid_string = lua.create_string(self.to_string().as_str())?;
         Ok(Value::String(uuid_string))
     }
 
     #[inline]
     unsafe fn push_into_stack(self, lua: &'lua Lua) -> Result<()> {
-        lua.push_ref(&self);
+        let uuid_string = lua.create_string(self.to_string().as_str())?;
+        lua.push_ref(&uuid_string.0);
         Ok(())
     }   
 }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -533,7 +533,10 @@ impl<'lua> FromLua<'lua> for uuid::Uuid {
             });
         match string_result {
             Ok(string) => {
-                Ok(uuid::Uuid::parse_str(string.to_str()?)?)
+                match uuid::Uuid::parse_str(string.to_str()?) {
+                    Ok(val) => Ok(val),
+                    Err(e) => Err(e)
+                }
             },
             Err(e) => Err(e)
         }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -533,7 +533,7 @@ impl<'lua> FromLua<'lua> for uuid::Uuid {
             });
         match string_result {
             Ok(string) => {
-                Ok(uuid::Uuid::parse_str(string.to_str()))
+                Ok(uuid::Uuid::parse_str(string.to_str()?))
             },
             Err(e) => Err(e)
         }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -544,7 +544,8 @@ impl<'lua> FromLua<'lua> for uuid::Uuid {
 impl<'lua> IntoLua<'lua> for uuid::Uuid {
     #[inline]
     fn into_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
-        Ok(Value::String(self.to_string()))
+        let uuid_string: String<'lua> = self.to_string();
+        Ok(Value::String(uuid_string))
     }
 }
 
@@ -552,12 +553,13 @@ impl<'lua> IntoLua<'lua> for uuid::Uuid {
 impl<'lua> IntoLua<'lua> for &uuid::Uuid {
     #[inline]
     fn into_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
-        Ok(Value::String(self.clone().to_string()))
+        let uuid_string: String<'lua> = self.clone().to_string();
+        Ok(Value::String(uuid_string))
     }
 
     #[inline]
     unsafe fn push_into_stack(self, lua: &'lua Lua) -> Result<()> {
-        lua.push_ref(&self.0);
+        lua.push_ref(&self);
         Ok(())
     }   
 }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -520,7 +520,7 @@ impl<'lua> FromLua<'lua> for LightUserData {
     }
 }
 
-#[cfg(feature = "uuid")]
+//#[cfg(feature = "uuid")]
 impl<'lua> IntoLua<'lua> for uuid::Uuid {
     #[inline]
     fn into_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
@@ -528,7 +528,7 @@ impl<'lua> IntoLua<'lua> for uuid::Uuid {
     }
 }
 
-#[cfg(feature = "uuid")]
+//#[cfg(feature = "uuid")]
 impl<'lua> IntoLua<'lua> for &uuid::Uuid {
     #[inline]
     fn into_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
@@ -537,25 +537,25 @@ impl<'lua> IntoLua<'lua> for &uuid::Uuid {
 
     #[inline]
     unsafe fn push_into_stack(self, lua: &'lua Lua) -> Result<()> {
-        lua.push_ref(&self.0);
+        lua.push_ref(&self.to_string().0);
         Ok(())
     }   
 }
 
-#[cfg(feature = "uuid")]
+//#[cfg(feature = "uuid")]
 impl<'lua> FromLua<'lua> for uuid::Uuid<'lua> {
     #[inline]
     fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<uuid::Uuid<'lua>> {
         let ty = value.type_name();
-        let string = lua.coerce_string(value)?
+        let string_result = lua.coerce_string(value)?
             .ok_or_else(|| Error::FromLuaConversionError {
                 from: ty,
                 to: "string",
                 message: Some("expected string or number".to_string()),
             });
-        match string {
-            Ok(str) => {
-                Ok(Uuid::parse_str(str.as_str()))
+        match string_result {
+            Ok(string) => {
+                Ok(Uuid::parse_str(string.as_str()))
             },
             Err(e) => Err(e)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,13 @@ pub use mlua_derive::chunk;
 #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 pub use mlua_derive::FromLua;
 
+/// Derive [`ToLua`] for a Rust type.
+/// 
+/// Nested types require [`IntoLua`] as well
+#[cfg(feature = "macros")]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+pub use mlua_derive::ToLua;
+
 /// Registers Lua module entrypoint.
 ///
 /// You can register multiple entrypoints as required.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,6 +232,14 @@ pub use mlua_derive::FromLua;
 #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 pub use mlua_derive::ToLua;
 
+#[cfg(feature = "macros")]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+pub use mlua_derive::ToLuaTable;
+
+#[cfg(feature = "macros")]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+pub use mlua_derive::FromLuaTable;
+
 /// Registers Lua module entrypoint.
 ///
 /// You can register multiple entrypoints as required.


### PR DESCRIPTION
I just made it but it seems useful so far, at least for me it is, works with most primitives so I think it's worth adding to help reduce boilerplate:

```rs
use mlua::{FromLua, Function, Lua, LuaOptions, StdLib, ToLua};
use serde::{Deserialize, Serialize};

#[derive(Debug, Serialize, Deserialize, FromLua, Clone, ToLua)] // new ToLua derive macro
struct MyType {
    x: u32,
    y: String,
}

fn main() {
    let lua = Lua::new_with(StdLib::ALL_SAFE, LuaOptions::default()).unwrap();
    

    let lua_code = r#"
        function(myType)
              print(myType.x, myType.y)
        end
    "#;


    let f: Function = lua.load(lua_code).eval().unwrap();

    let my_type = MyType {
        x: 6,
        y: "hi, from rust to lua".into()
    };

    f.call::<MyType, ()>(my_type).unwrap();

}
```
