### PR TITLE
Reduce compile time contribution of `next_key_seed` and `next_value_seed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Removed `UserData` impl for Rc/Arc types ("any" userdata functions can be used instead)
 - `Lua::replace_registry_value` takes `&mut RegistryKey`
 - `Lua::scope` temporary disabled (will be re-added in the next release)
+- Reduced the compile time contribution of `next_key_seed` and `next_value_seed`.
 
 ## v0.9.9
 


### PR DESCRIPTION
The `next_key_seed` and `next_value_seed` produce many LLVM IR lines, slowing down the compilation. They only need to generate a fraction of the lines as they can share most of the code.

`deserialize_map` and `serde_userdata` are also candidates for optimization, but this PR does not touch them.