### PR TITLE
`serde_userdata`: Remove `map_err` to reduce compile time impact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `Lua::replace_registry_value` takes `&mut RegistryKey`
 - `Lua::scope` temporary disabled (will be re-added in the next release)
 - Reduced the compile time contribution of `next_key_seed` and `next_value_seed`.
+- Reduced the compile time contribution of `serde_userdata`.
 
 ## v0.9.9
 
@@ -128,23 +129,27 @@ Changes since v0.9.0-rc.3
 - Added `UserDataFields::add_field()` method to add static fields to UserData
 
 Breaking changes:
+
 - Require environment to be a `Table` instead of `Value` in Chunks.
 - `AsChunk::env()` renamed to `AsChunk::environment()`
 
 ## v0.9.0-beta.2
 
 New features:
+
 - Added `Thread::set_hook()` function to set hook on threads
 - Added pretty print to the Debug formatting to Lua `Value` and `Table`
 - ffi layer moved to `mlua-sys` crate
 - Added OwnedString (unstable)
 
 Breaking changes:
+
 - Refactor `HookTriggers` (make it const)
 
 ## v0.9.0-beta.1
 
 New features:
+
 - Owned Lua types (unstable feature flag)
 - New functions `Function::wrap`/`Function::wrap_mut`/`Function::wrap_async`
 - `Lua::register_userdata_type()` to register a custom userdata types (without requiring `UserData` trait)
@@ -153,11 +158,12 @@ New features:
 - Added `AnyUserDataExt` trait with auxiliary functions for `AnyUserData`
 - Added `UserDataRef` and `UserDataRefMut` type wrapped that implement `FromLua`
 - Improved error handling:
-  * Improved error reporting when calling Rust functions from Lua.
-  * Added `Error::BadArgument` to help identify bad argument position or name
-  * Added `ErrorContext` extension trait to attach additional context to `Error`
+  - Improved error reporting when calling Rust functions from Lua.
+  - Added `Error::BadArgument` to help identify bad argument position or name
+  - Added `ErrorContext` extension trait to attach additional context to `Error`
 
 Breaking changes:
+
 - Refactored `AsChunk` trait
 - `ToLua`/`ToLuaMulti` renamed to `IntoLua`/`IntoLuaMulti`
 - Renamed `to_lua_err` to `into_lua_err`
@@ -166,6 +172,7 @@ Breaking changes:
 - Added `&Lua` arg to Luau interrupt callback
 
 Other:
+
 - Better Debug for String
 - Allow deserializing values from serializable UserData using `Lua::from_value()` method
 - Added `Table::clear()` method
@@ -189,7 +196,7 @@ Other:
 ## v0.8.8
 
 - Fix potential deadlock when trying to reuse dropped registry keys.
-- Optimize userdata methods call when __index and fields_getters are nil
+- Optimize userdata methods call when \_\_index and fields_getters are nil
 
 ## v0.8.7
 
@@ -234,7 +241,9 @@ Other:
 - Bugfixes and improvements (#176 #179)
 
 ## v0.8.0
+
 Changes since 0.7.4
+
 - Roblox Luau support
 - Removed C glue
 - Added async support to `__index` and `__newindex` metamethods
@@ -245,6 +254,7 @@ Changes since 0.7.4
 - Performance improvements
 
 Breaking changes:
+
 - Refactored `AsChunk` trait (added implementation for `Path` and `PathBuf`).
 
 ## v0.8.0-beta.5
@@ -366,7 +376,9 @@ Breaking changes:
 - `once_cell` dependency lowered to 1.0
 
 ## v0.6.0
+
 Changes since 0.5.4
+
 - New `UserDataFields` API
 - Full access to `UserData` metatables with support of setting arbitrary fields.
 - Implement `UserData` for `Rc<RefCell<T>>`/`Arc<Mutex<T>>`/`Arc<RwLock<T>>` where `T: UserData`.
@@ -380,6 +392,7 @@ Changes since 0.5.4
 - Various bugfixes and improvements
 
 Breaking changes:
+
 - Errors are always `Send + Sync` to be compatible with the anyhow crate.
 - Removed `Result` from `LuaSerdeExt::null()` and `LuaSerdeExt::array_metatable()` (never fails)
 - Removed `Result` from `Function::dump()` (never fails)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,27 +129,23 @@ Changes since v0.9.0-rc.3
 - Added `UserDataFields::add_field()` method to add static fields to UserData
 
 Breaking changes:
-
 - Require environment to be a `Table` instead of `Value` in Chunks.
 - `AsChunk::env()` renamed to `AsChunk::environment()`
 
 ## v0.9.0-beta.2
 
 New features:
-
 - Added `Thread::set_hook()` function to set hook on threads
 - Added pretty print to the Debug formatting to Lua `Value` and `Table`
 - ffi layer moved to `mlua-sys` crate
 - Added OwnedString (unstable)
 
 Breaking changes:
-
 - Refactor `HookTriggers` (make it const)
 
 ## v0.9.0-beta.1
 
 New features:
-
 - Owned Lua types (unstable feature flag)
 - New functions `Function::wrap`/`Function::wrap_mut`/`Function::wrap_async`
 - `Lua::register_userdata_type()` to register a custom userdata types (without requiring `UserData` trait)
@@ -158,12 +154,11 @@ New features:
 - Added `AnyUserDataExt` trait with auxiliary functions for `AnyUserData`
 - Added `UserDataRef` and `UserDataRefMut` type wrapped that implement `FromLua`
 - Improved error handling:
-  - Improved error reporting when calling Rust functions from Lua.
-  - Added `Error::BadArgument` to help identify bad argument position or name
-  - Added `ErrorContext` extension trait to attach additional context to `Error`
+  * Improved error reporting when calling Rust functions from Lua.
+  * Added `Error::BadArgument` to help identify bad argument position or name
+  * Added `ErrorContext` extension trait to attach additional context to `Error`
 
 Breaking changes:
-
 - Refactored `AsChunk` trait
 - `ToLua`/`ToLuaMulti` renamed to `IntoLua`/`IntoLuaMulti`
 - Renamed `to_lua_err` to `into_lua_err`
@@ -172,7 +167,6 @@ Breaking changes:
 - Added `&Lua` arg to Luau interrupt callback
 
 Other:
-
 - Better Debug for String
 - Allow deserializing values from serializable UserData using `Lua::from_value()` method
 - Added `Table::clear()` method
@@ -196,7 +190,7 @@ Other:
 ## v0.8.8
 
 - Fix potential deadlock when trying to reuse dropped registry keys.
-- Optimize userdata methods call when \_\_index and fields_getters are nil
+- Optimize userdata methods call when __index and fields_getters are nil
 
 ## v0.8.7
 
@@ -241,9 +235,7 @@ Other:
 - Bugfixes and improvements (#176 #179)
 
 ## v0.8.0
-
 Changes since 0.7.4
-
 - Roblox Luau support
 - Removed C glue
 - Added async support to `__index` and `__newindex` metamethods
@@ -254,7 +246,6 @@ Changes since 0.7.4
 - Performance improvements
 
 Breaking changes:
-
 - Refactored `AsChunk` trait (added implementation for `Path` and `PathBuf`).
 
 ## v0.8.0-beta.5
@@ -376,9 +367,7 @@ Breaking changes:
 - `once_cell` dependency lowered to 1.0
 
 ## v0.6.0
-
 Changes since 0.5.4
-
 - New `UserDataFields` API
 - Full access to `UserData` metatables with support of setting arbitrary fields.
 - Implement `UserData` for `Rc<RefCell<T>>`/`Arc<Mutex<T>>`/`Arc<RwLock<T>>` where `T: UserData`.
@@ -392,7 +381,6 @@ Changes since 0.5.4
 - Various bugfixes and improvements
 
 Breaking changes:
-
 - Errors are always `Send + Sync` to be compatible with the anyhow crate.
 - Removed `Result` from `LuaSerdeExt::null()` and `LuaSerdeExt::array_metatable()` (never fails)
 - Removed `Result` from `Function::dump()` (never fails)

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -719,6 +719,11 @@ fn serde_userdata<V>(
     ud: AnyUserData,
     f: impl FnOnce(serde_value::Value) -> std::result::Result<V, serde_value::DeserializerError>,
 ) -> Result<V> {
-    let value = serde_value::to_value(ud).map_err(|err| Error::SerializeError(err.to_string()))?;
-    f(value).map_err(|err| Error::DeserializeError(err.to_string()))
+    match serde_value::to_value(ud) {
+        Ok(value) => match f(value) {
+            Ok(r) => Ok(r),
+            Err(error) => Err(Error::SerializeError(error.to_string())),
+        },
+        Err(error) => Err(Error::DeserializeError(error.to_string())),
+    }
 }

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -722,8 +722,8 @@ fn serde_userdata<V>(
     match serde_value::to_value(ud) {
         Ok(value) => match f(value) {
             Ok(r) => Ok(r),
-            Err(error) => Err(Error::SerializeError(error.to_string())),
+            Err(error) => Err(Error::DeserializeError(error.to_string())),
         },
-        Err(error) => Err(Error::DeserializeError(error.to_string())),
+        Err(error) => Err(Error::SerializeError(error.to_string())),
     }
 }


### PR DESCRIPTION
`map_err` has a disproportionate impact on the LLVM IR generated. In generic functions it's beneficial for compile times to avoid it. This reduces the LLVM lines of a crate that heavily uses mlua from 2420270 to 2302295. It could be reduced by a further 50000 lines by manually inlining `serde_userdata`, but as that would make the code a bit less readable I'm holding off on that.