### PR TITLE
Change chunk env to use luau's lua_load env parameter

### DIFF
--- a/mlua-sys/src/luau/compat.rs
+++ b/mlua-sys/src/luau/compat.rs
@@ -326,6 +326,7 @@ pub unsafe fn luaL_loadbufferx(
     mut size: usize,
     name: *const c_char,
     mode: *const c_char,
+    env: c_int
 ) -> c_int {
     extern "C" {
         fn free(p: *mut c_void);
@@ -345,12 +346,12 @@ pub unsafe fn luaL_loadbufferx(
 
     if chunk_is_text {
         let data = luau_compile_(data, size, ptr::null_mut(), &mut size);
-        let ok = luau_load(L, name, data, size, 0) == 0;
+        let ok = luau_load(L, name, data, size, env) == 0;
         free(data as *mut c_void);
         if !ok {
             return LUA_ERRSYNTAX;
         }
-    } else if luau_load(L, name, data, size, 0) != 0 {
+    } else if luau_load(L, name, data, size, env) != 0 {
         return LUA_ERRSYNTAX;
     }
     LUA_OK
@@ -361,9 +362,9 @@ pub unsafe fn luaL_loadbuffer(
     L: *mut lua_State,
     data: *const c_char,
     size: usize,
-    name: *const c_char,
+    name: *const c_char
 ) -> c_int {
-    luaL_loadbufferx(L, data, size, name, ptr::null())
+    luaL_loadbufferx(L, data, size, name, ptr::null(), 0)
 }
 
 #[inline(always)]

--- a/src/state/raw.rs
+++ b/src/state/raw.rs
@@ -319,13 +319,22 @@ impl RawLua {
                 source.len(),
                 name.map(|n| n.as_ptr()).unwrap_or_else(ptr::null),
                 mode_str,
+                #[cfg(feature="luau")]
+                match &env {
+                    Some(env) => {
+                        self.push_ref(&env.0);
+                        -1
+                    }
+                    _ => 0
+                },
             ) {
                 ffi::LUA_OK => {
                     if let Some(env) = env {
+                        #[cfg(not(feature="luau"))]
                         self.push_ref(&env.0);
                         #[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
                         ffi::lua_setupvalue(state, -2, 1);
-                        #[cfg(any(feature = "lua51", feature = "luajit", feature = "luau"))]
+                        #[cfg(any(feature = "lua51", feature = "luajit"))]
                         ffi::lua_setfenv(state, -2);
                     }
 


### PR DESCRIPTION
Luau provides a parameter to `lua_load` which is a stack index for the environment which a chunk should be loaded with.

Using this over setfenv is preferred as setfenv impacts or entirely impedes Luau's JIT compilation.

This should also be backported to v0.9