### PR TITLE
Update documentation of traits to match the expected argument name

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -33,13 +33,13 @@ pub trait ObjectLike: Sealed {
     where
         R: FromLuaMulti;
 
-    /// Gets the function associated to `key` from the object and calls it,
+    /// Gets the function associated to key `name` from the object and calls it,
     /// passing the object itself along with `args` as function arguments.
     fn call_method<R>(&self, name: &str, args: impl IntoLuaMulti) -> Result<R>
     where
         R: FromLuaMulti;
 
-    /// Gets the function associated to `key` from the object and asynchronously calls it,
+    /// Gets the function associated to key `name` from the object and asynchronously calls it,
     /// passing the object itself along with `args` as function arguments.
     ///
     /// Requires `feature = "async"`
@@ -51,7 +51,7 @@ pub trait ObjectLike: Sealed {
     where
         R: FromLuaMulti;
 
-    /// Gets the function associated to `key` from the object and calls it,
+    /// Gets the function associated to key `name` from the object and calls it,
     /// passing `args` as function arguments.
     ///
     /// This might invoke the `__index` metamethod.
@@ -59,7 +59,7 @@ pub trait ObjectLike: Sealed {
     where
         R: FromLuaMulti;
 
-    /// Gets the function associated to `key` from the object and asynchronously calls it,
+    /// Gets the function associated to key `name` from the object and asynchronously calls it,
     /// passing `args` as function arguments.
     ///
     /// Requires `feature = "async"`


### PR DESCRIPTION
While working on my issue #446 I was a bit puzzled by the docs. Everything seemed a bit cryptic and it still isn't apparent to me what types to set where, but at the very least it didn't help that the functions actually take an argument called 'name' while the docs refer to it as 'key'.

This is against the *main* branch for v0.10. If you would prefer it for v0.9 instead (or too) I can make the change there.