### PR TITLE
feat(table): improve pretty-printing for simple tables and lists

### DIFF
--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -7,7 +7,7 @@ fn test_debug_format() -> Result<()> {
     // Globals
     let globals = lua.globals();
     let dump = format!("{globals:#?}");
-    assert!(dump.starts_with("{\n  [\"_G\"] = table:"));
+    assert!(dump.starts_with("{\n  _G = table:"));
 
     // TODO: Other cases
 

--- a/tests/table.rs
+++ b/tests/table.rs
@@ -397,6 +397,7 @@ fn test_table_fmt() -> Result<()> {
         .load(
             r#"
         local t = {1, 2, 3, a = 5, b = { 6 }}
+        t["special-<chars>"] = 10
         t[9.2] = 9.2
         t[1.99] = 1.99
         t[true] = true
@@ -410,7 +411,7 @@ fn test_table_fmt() -> Result<()> {
     // Pretty print
     assert_eq!(
         format!("{table:#?}"),
-        "{\n  [false] = false,\n  [true] = true,\n  [1] = 1,\n  [1.99] = 1.99,\n  [2] = 2,\n  [3] = 3,\n  [9.2] = 9.2,\n  [\"a\"] = 5,\n  [\"b\"] = {\n    [1] = 6,\n  },\n}"
+        "{\n  [false] = false,\n  [true] = true,\n  [1] = 1,\n  [1.99] = 1.99,\n  [2] = 2,\n  [3] = 3,\n  [9.2] = 9.2,\n  a = 5,\n  b = {\n    6,\n  },\n  [\"special-<chars>\"] = 10,\n}"
     );
 
     Ok(())


### PR DESCRIPTION
Hi,

This PR improves the pretty printing code for Lua tables:
- Adds support for list rendering
- Adds support for rendering simple keys (`["hello"] = 3`) as just `hello = 3`

The use case for this is reading in a Lua file (like a rockspec), modifying its globals and then reconstructing the Lua file in a readable format. Given that debug pretty printing is for debugging (duh), I'm not classifying this as any sort of breaking change :)

One note: the `is_sequence` check goes through all keys in a table and checks if they're integers and in ascending order. The `is_list()` method is only for `cfg!(serialize)`, so I've refrained from refactoring that in fear of breaking some obscure behaviour. Let me know if there's anything you'd change!