### PR TITLE
Set Default for LuaValue to be nil.

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -569,6 +569,12 @@ impl Value {
     }
 }
 
+impl Default for Value {
+    fn default() -> Self {
+        Self::Nil
+    }
+}
+
 impl fmt::Debug for Value {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         if fmt.alternate() {


### PR DESCRIPTION
I was surprised there was no Default implemented for LuaValue, so it exists now.