### PR TITLE
Add resume_error to Thread for luau

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ members = [
 ]
 
 [features]
-default = ["luau"]
 lua54 = ["ffi/lua54"]
 lua53 = ["ffi/lua53"]
 lua52 = ["ffi/lua52"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
 ]
 
 [features]
+default = ["luau"]
 lua54 = ["ffi/lua54"]
 lua53 = ["ffi/lua53"]
 lua52 = ["ffi/lua52"]

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -174,6 +174,8 @@ impl Thread {
         }
     }
 
+    #[cfg(feature = "luau")]
+    /// Resumes a thread with an error.
     pub fn resume_error<R>(&self, args: impl IntoLua) -> Result<R>
     where
         R: FromLuaMulti,
@@ -224,9 +226,10 @@ impl Thread {
         }
     }
 
-    /// Resumes execution of this thread.
+    #[cfg(feature = "luau")]
+    /// Resumes execution of this thread with an error.
     ///
-    /// It's similar to `resume()` but leaves `nresults` values on the thread stack.
+    /// It's similar to `resume_error()` but leaves `nresults` values on the thread stack.
     unsafe fn resumeerror_inner(&self, lua: &RawLua) -> Result<(ThreadStatusInner, c_int)> {
         let state = lua.state();
         let thread_state = self.state();
@@ -674,7 +677,7 @@ mod resumeerror_test {
                 "#,
                 )
                 .call(
-                    lua.create_function(|lua, th: Thread| {
+                    lua.create_function(|_lua, th: Thread| {
                         tokio::task::spawn_local(async move {
                             println!("Thread: {:?}, {:?}", th, th.status());
                             th.resume_error::<()>("An error here".to_string()).unwrap();

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -188,7 +188,7 @@ impl Thread {
         let thread_state = self.state();
         unsafe {
             let _sg = StackGuard::new(state);
-            let _thread_sg = StackGuard::new(thread_state);
+            let _thread_sg = StackGuard::with_top(thread_state, 0);
 
             check_stack(state, 1)?;
             args.push_into_stack(&lua)?;


### PR DESCRIPTION
This adds support for the Luau specific ``lua_resumeerror`` to mlua dev branch as Thread::resume_error which allows directly resuming a thread with a bubbled up error which is at the top of the threads stack. This can be useful for many situations including resuming coroutine yields but as a bubbled up error with working pcall etc.

This C API is increasingly used by luau runtimes for error handling in threads which is how I found out about it:

```c
void luauv_scheduler_spawnerror(lua_State* thread, lua_State* from, const char* fmt, ...) {
    va_list args;
    va_start(args, fmt);
    lua_pushvfstring(thread, fmt, args);
    va_end(args);

    int status = lua_resumeerror(thread, from);
    handlestatus(thread, status);
}
```

Hence why I made a pr for mlua to add it @khvzak 

The API in question takes in a single argument of type IntoLua which is pushed to top of thread stack. Resume error is called and gettop is used to get the results and then IntoLuaMulti is used to convert to desired value.

For sample usage of this API:

```rust
                let fut = async move {
                    let res = fut.await;

                    match res {
                        Ok(res) => {
                            *taskmgr.inner.pending_asyncs.borrow_mut() -= 1;

                            #[cfg(not(feature = "fast"))]
                            let result = taskmgr.resume_thread_fast(th.clone(), res).await;
                            #[cfg(feature = "fast")]
                            let result = taskmgr.resume_thread_fast(&th, res);

                            taskmgr.inner.feedback.on_response(
                                "AsyncThread",
                                &taskmgr,
                                &th,
                                result,
                            );
                        }
                        Err(err) => {
                            *taskmgr.inner.pending_asyncs.borrow_mut() -= 1;

                            #[cfg(not(feature = "fast"))]
                            let result = taskmgr.resume_thread_fast(th.clone(), result).await;
                            #[cfg(feature = "fast")]
                            let result = th.resume_error::<LuaMultiValue>(err.to_string());

                            taskmgr.inner.feedback.on_response(
                                "AsyncThread.Resume",
                                &taskmgr,
                                &th,
                                Some(result),
                            );
                        }
                    }
                };

                #[cfg(not(feature = "send"))]
                async_executor.spawn_local(fut);
                #[cfg(feature = "send")]
                async_executor.spawn(fut);

                Ok(())
            },
        )?)?;
```

Without lua_resumeerror, doing the above requires monkeypatching coroutine.yield to get errors to correctly bubble which then breaks pcall. With lua_resumeerror, the above just works with fully working error propagation and pcall fully working as desired (and is also more performant).

Also, merging this PR would solve the original issue of https://github.com/mlua-rs/mlua/issues/500 regarding erroring yielded threads. It turns out ``lua_resumeerror`` is the Luau solution for this.