### PR TITLE
fix: Gracefully handle errors when disabling C modules

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -213,7 +213,9 @@ impl Lua {
         let lua = unsafe { Self::inner_new(libs, options) };
 
         if libs.contains(StdLib::PACKAGE) {
-            mlua_expect!(lua.disable_c_modules(), "Error disabling C modules");
+            // This may already have been done at compile time,
+            // so we need to handle this gracefully.
+            let _ = lua.disable_c_modules();
         }
         lua.lock().mark_safe();
 


### PR DESCRIPTION
This PR makes a small change to `mlua` so it no longer panics when unable to disable C modules.

This is primarily meant for [Pluto](https://pluto-lang.org/), which has sandbox options that [fully disable](https://github.com/PlutoLang/Pluto/blob/08914224b1d3a2fb4657f4db7571295fa48ca79b/src/loadlib.cpp#L751-L759) loading C modules, which would otherwise conflict with `mlua` also trying to disable a loader that no longer exists.

I'm not 100% sure if throwing the error away is the best solution, but it seems **extremely unlikely** that this would fail in any logical sense besides `package.loadlib` or the `searchers` not existing, in which case the end goal was already reached (being unable to load any C modules).

I'm happy to fix this differently if you have any other ideas!