### PR TITLE
Fix new clippy lints

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -27,7 +27,7 @@ impl MemoryState {
             mlua_assert!(!mem_state.is_null(), "Luau state has no allocator userdata");
         }
         #[cfg(not(feature = "luau"))]
-        if ffi::lua_getallocf(state, &mut mem_state) != ALLOCATOR {
+        if !std::ptr::fn_addr_eq(ffi::lua_getallocf(state, &mut mem_state), ALLOCATOR) {
             mem_state = ptr::null_mut();
         }
         mem_state as *mut MemoryState

--- a/src/value.rs
+++ b/src/value.rs
@@ -272,7 +272,11 @@ impl Value {
     /// If the value is a Lua [`Integer`], try to convert it to `i64` or return `None` otherwise.
     #[inline]
     pub fn as_i64(&self) -> Option<i64> {
-        self.as_integer().map(i64::from)
+        if cfg!(target_pointer_width = "64") {
+            self.as_integer()
+        } else {
+            self.as_integer().map(i64::from)
+        }
     }
 
     /// Cast the value to `u64`.


### PR DESCRIPTION
This PR closes #535 which calls out 2 new clippy lints, each lint is fixed in its own commits.

The first fix moves from validating the allocator function matches the static defined in memory.rs to use `std::ptr::fn_addr_eq` as suggested by the clippy lint

The second fix adds a compile time check for the size of `ffi::Integer` to ensure that the `map` in `as_i64` is only performed when approprate