### PR TITLE
fix: normalize_chunk_name handles Windows paths with drive letter

### DIFF
--- a/src/luau/require.rs
+++ b/src/luau/require.rs
@@ -129,7 +129,7 @@ impl TextRequirer {
     }
 
     fn normalize_chunk_name(chunk_name: &str) -> &str {
-        if let Some((path, line)) = chunk_name.split_once(':') {
+        if let Some((path, line)) = chunk_name.rsplit_once(':') {
             if line.parse::<u32>().is_ok() {
                 return path;
             }


### PR DESCRIPTION
Replace split_once(':') with rsplit_once(':') to correctly handle Windows drive letters like C:\path:123. This avoids incorrectly splitting the path at the drive letter colon.