### PR TITLE
Build/test wasm32-wasip2 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -256,6 +256,41 @@ jobs:
           cargo test --tests --features "${{ matrix.lua }},vendored"
           cargo test --tests --features "${{ matrix.lua }},vendored,async,serde,macros,anyhow,userdata-wrappers"
 
+  test_wasm32_wasip2:
+    name: Test on wasm32-wasip2
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        lua: [lua54, lua53, lua52, lua51]
+    steps:
+      - uses: actions/checkout@main
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly-2025-10-02
+          target: wasm32-wasip2
+      - name: Install wasi-sdk/Wasmtime
+        working-directory: ${{ runner.tool_cache }}
+        run: |
+          wasi_sdk=27
+          wasmtime=v37.0.1
+
+          curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$wasi_sdk/wasi-sdk-$wasi_sdk.0-x86_64-linux.tar.gz
+          tar xf wasi-sdk-$wasi_sdk.0-x86_64-linux.tar.gz
+          WASI_SDK_PATH=`pwd`/wasi-sdk-$wasi_sdk.0-x86_64-linux
+          echo "WASI_SDK_PATH=$WASI_SDK_PATH" >> $GITHUB_ENV
+          echo "CC_wasm32_wasip2=$WASI_SDK_PATH/bin/clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_WASM32_WASIP2_LINKER=$WASI_SDK_PATH/bin/clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_WASM32_WASIP2_RUSTFLAGS=-Clink-arg=-Wl,--export=cabi_realloc" >> $GITHUB_ENV
+
+          curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/$wasmtime/wasmtime-$wasmtime-x86_64-linux.tar.xz
+          tar xf wasmtime-$wasmtime-x86_64-linux.tar.xz
+          echo "CARGO_TARGET_WASM32_WASIP2_RUNNER=`pwd`/wasmtime-$wasmtime-x86_64-linux/wasmtime -W exceptions" >> $GITHUB_ENV
+      - name: Run ${{ matrix.lua }} tests
+        run: |
+          cargo test --target wasm32-wasip2 --tests --features "${{ matrix.lua }},vendored"
+          cargo test --target wasm32-wasip2 --tests --features "${{ matrix.lua }},vendored,serde,macros,anyhow,userdata-wrappers"
+
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,18 +66,18 @@ ffi = { package = "mlua-sys", version = "0.8.3", path = "mlua-sys" }
 
 [dev-dependencies]
 trybuild = "1.0"
-hyper = { version = "1.2", features = ["full"] }
-hyper-util = { version = "0.1.3", features = ["full"] }
-http-body-util = "0.1.1"
-reqwest = { version = "0.12", features = ["json"] }
 tokio = { version = "1.0", features = ["macros", "rt", "time"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 maplit = "1.0"
-tempfile = "3"
 static_assertions = "1.0"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
+hyper = { version = "1.2", features = ["full"] }
+hyper-util = { version = "0.1.3", features = ["full"] }
+http-body-util = "0.1.1"
+reqwest = { version = "0.12", features = ["json"] }
+tempfile = "3"
 criterion = { version = "0.7", features = ["async_tokio"] }
 rustyline = "17.0"
 tokio = { version = "1.0", features = ["full"] }

--- a/tests/chunk.rs
+++ b/tests/chunk.rs
@@ -21,6 +21,7 @@ fn test_chunk_methods() -> Result<()> {
 }
 
 #[test]
+#[cfg(not(target_os = "wasi"))]
 fn test_chunk_path() -> Result<()> {
     let lua = Lua::new();
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -394,6 +394,7 @@ fn test_error() -> Result<()> {
 }
 
 #[test]
+#[cfg(not(panic = "abort"))]
 fn test_panic() -> Result<()> {
     fn make_lua(options: LuaOptions) -> Result<Lua> {
         let lua = Lua::new_with(StdLib::ALL_SAFE, options)?;
@@ -897,6 +898,7 @@ fn test_registry_value_reuse() -> Result<()> {
 }
 
 #[test]
+#[cfg(not(panic = "abort"))]
 fn test_application_data() -> Result<()> {
     let lua = Lua::new();
 

--- a/tests/thread.rs
+++ b/tests/thread.rs
@@ -199,6 +199,7 @@ fn test_coroutine_from_closure() -> Result<()> {
 }
 
 #[test]
+#[cfg(not(panic = "abort"))]
 fn test_coroutine_panic() {
     match catch_unwind(|| -> Result<()> {
         // check that coroutines propagate panics correctly


### PR DESCRIPTION
This is a follow-up from mlua-rs/lua-src-rs#13 which verifies/tests that mlua/lua all work when compiled for a WASI target. While this doesn't have formal documentation yet it also codifies in CI configuration how to build for WASI and get tests passing (notably C compiler configuration and some misc Rust flags).

This moves some `dev-dependencies` that don't compile for `wasm32-wasip2` to a different section of the manifest. This additionally annotates panicking tests with `#[cfg(not(panic = "abort"))]` to skip those tests on WASI.

This does not test either the `send` or `async` feature at this time. Testing `send` requires threads which WASI does not yet support, and testing `async` requires more support in Tokio which is not currently there yet.

Closes #366