### PR TITLE
Fix typos and stderr test output for rustc 1.92.

### DIFF
--- a/src/luau/json.rs
+++ b/src/luau/json.rs
@@ -313,8 +313,8 @@ mod tests {
     fn test_error_cases() {
         assert!(parse("").is_err());
         assert!(parse("nul").is_err());
-        assert!(parse("tru").is_err());
-        assert!(parse("fals").is_err());
+        assert!(parse("tru").is_err()); // spellchecker:disable-line
+        assert!(parse("fals").is_err()); // spellchecker:disable-line
         assert!(parse(r#""unterminated"#).is_err());
         assert!(parse("[1,2,]").is_err());
         assert!(parse(r#"{"key""#).is_err());

--- a/src/state.rs
+++ b/src/state.rs
@@ -2098,7 +2098,7 @@ impl Lua {
 
     /// Suspends the current async function, returning the provided arguments to caller.
     ///
-    /// This function is similar to [`coroutine.yield`] but allow yeilding Rust functions
+    /// This function is similar to [`coroutine.yield`] but allow yielding Rust functions
     /// and passing values to the caller.
     /// Please note that you cannot cross [`Thread`] boundaries (e.g. calling `yield_with` on one
     /// thread and resuming on another).

--- a/tests/compile/lua_norefunwindsafe.stderr
+++ b/tests/compile/lua_norefunwindsafe.stderr
@@ -1,17 +1,14 @@
-error[E0277]: the type `UnsafeCell<*mut lua_State>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+error[E0277]: the type `UnsafeCell<*mut lua_State>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
  --> tests/compile/lua_norefunwindsafe.rs:7:18
   |
 7 |     catch_unwind(|| lua.create_table().unwrap());
-  |     ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<*mut lua_State>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+  |     ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<*mut lua_State>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
   |     |
   |     required by a bound introduced by this call
   |
   = help: within `mlua::types::sync::inner::ReentrantMutex<mlua::state::raw::RawLua>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<*mut lua_State>`
 note: required because it appears within the type `Cell<*mut lua_State>`
  --> $RUST/core/src/cell.rs
-  |
-  | pub struct Cell<T: ?Sized> {
-  |            ^^^^
 note: required because it appears within the type `mlua::state::raw::RawLua`
  --> src/state/raw.rs
   |
@@ -36,15 +33,12 @@ note: required because it's used within this closure
   |                  ^^
 note: required by a bound in `std::panic::catch_unwind`
  --> $RUST/std/src/panic.rs
-  |
-  | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
-  |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
 
-error[E0277]: the type `UnsafeCell<mlua::state::extra::ExtraData>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+error[E0277]: the type `UnsafeCell<mlua::state::extra::ExtraData>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
  --> tests/compile/lua_norefunwindsafe.rs:7:18
   |
 7 |     catch_unwind(|| lua.create_table().unwrap());
-  |     ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<mlua::state::extra::ExtraData>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+  |     ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<mlua::state::extra::ExtraData>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
   |     |
   |     required by a bound introduced by this call
   |
@@ -74,6 +68,3 @@ note: required because it's used within this closure
   |                  ^^
 note: required by a bound in `std::panic::catch_unwind`
  --> $RUST/std/src/panic.rs
-  |
-  | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
-  |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`

--- a/tests/compile/ref_nounwindsafe.stderr
+++ b/tests/compile/ref_nounwindsafe.stderr
@@ -1,28 +1,19 @@
-error[E0277]: the type `UnsafeCell<usize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+error[E0277]: the type `UnsafeCell<usize>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
  --> tests/compile/ref_nounwindsafe.rs:8:18
   |
 8 |     catch_unwind(move || table.set("a", "b").unwrap());
-  |     ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<usize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+  |     ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<usize>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
   |     |
   |     required by a bound introduced by this call
   |
   = help: within `rc::RcInner<mlua::types::sync::inner::ReentrantMutex<mlua::state::raw::RawLua>>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<usize>`
 note: required because it appears within the type `Cell<usize>`
  --> $RUST/core/src/cell.rs
-  |
-  | pub struct Cell<T: ?Sized> {
-  |            ^^^^
 note: required because it appears within the type `rc::RcInner<mlua::types::sync::inner::ReentrantMutex<mlua::state::raw::RawLua>>`
  --> $RUST/alloc/src/rc.rs
-  |
-  | struct RcInner<T: ?Sized> {
-  |        ^^^^^^^
   = note: required for `NonNull<rc::RcInner<mlua::types::sync::inner::ReentrantMutex<mlua::state::raw::RawLua>>>` to implement `UnwindSafe`
 note: required because it appears within the type `std::rc::Weak<mlua::types::sync::inner::ReentrantMutex<mlua::state::raw::RawLua>>`
  --> $RUST/alloc/src/rc.rs
-  |
-  | pub struct Weak<
-  |            ^^^^
 note: required because it appears within the type `WeakLua`
  --> src/state.rs
   |
@@ -45,24 +36,18 @@ note: required because it's used within this closure
   |                  ^^^^^^^
 note: required by a bound in `std::panic::catch_unwind`
  --> $RUST/std/src/panic.rs
-  |
-  | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
-  |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
 
-error[E0277]: the type `UnsafeCell<*mut lua_State>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+error[E0277]: the type `UnsafeCell<*mut lua_State>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
  --> tests/compile/ref_nounwindsafe.rs:8:18
   |
 8 |     catch_unwind(move || table.set("a", "b").unwrap());
-  |     ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<*mut lua_State>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+  |     ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<*mut lua_State>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
   |     |
   |     required by a bound introduced by this call
   |
   = help: within `rc::RcInner<mlua::types::sync::inner::ReentrantMutex<mlua::state::raw::RawLua>>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<*mut lua_State>`
 note: required because it appears within the type `Cell<*mut lua_State>`
  --> $RUST/core/src/cell.rs
-  |
-  | pub struct Cell<T: ?Sized> {
-  |            ^^^^
 note: required because it appears within the type `mlua::state::raw::RawLua`
  --> src/state/raw.rs
   |
@@ -75,15 +60,9 @@ note: required because it appears within the type `mlua::types::sync::inner::Ree
   |                       ^^^^^^^^^^^^^^
 note: required because it appears within the type `rc::RcInner<mlua::types::sync::inner::ReentrantMutex<mlua::state::raw::RawLua>>`
  --> $RUST/alloc/src/rc.rs
-  |
-  | struct RcInner<T: ?Sized> {
-  |        ^^^^^^^
   = note: required for `NonNull<rc::RcInner<mlua::types::sync::inner::ReentrantMutex<mlua::state::raw::RawLua>>>` to implement `UnwindSafe`
 note: required because it appears within the type `std::rc::Weak<mlua::types::sync::inner::ReentrantMutex<mlua::state::raw::RawLua>>`
  --> $RUST/alloc/src/rc.rs
-  |
-  | pub struct Weak<
-  |            ^^^^
 note: required because it appears within the type `WeakLua`
  --> src/state.rs
   |
@@ -106,15 +85,12 @@ note: required because it's used within this closure
   |                  ^^^^^^^
 note: required by a bound in `std::panic::catch_unwind`
  --> $RUST/std/src/panic.rs
-  |
-  | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
-  |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
 
-error[E0277]: the type `UnsafeCell<mlua::state::extra::ExtraData>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+error[E0277]: the type `UnsafeCell<mlua::state::extra::ExtraData>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
  --> tests/compile/ref_nounwindsafe.rs:8:18
   |
 8 |     catch_unwind(move || table.set("a", "b").unwrap());
-  |     ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<mlua::state::extra::ExtraData>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+  |     ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<mlua::state::extra::ExtraData>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
   |     |
   |     required by a bound introduced by this call
   |
@@ -132,15 +108,9 @@ note: required because it appears within the type `mlua::types::sync::inner::Ree
   |                       ^^^^^^^^^^^^^^
 note: required because it appears within the type `rc::RcInner<mlua::types::sync::inner::ReentrantMutex<mlua::state::raw::RawLua>>`
  --> $RUST/alloc/src/rc.rs
-  |
-  | struct RcInner<T: ?Sized> {
-  |        ^^^^^^^
   = note: required for `NonNull<rc::RcInner<mlua::types::sync::inner::ReentrantMutex<mlua::state::raw::RawLua>>>` to implement `UnwindSafe`
 note: required because it appears within the type `std::rc::Weak<mlua::types::sync::inner::ReentrantMutex<mlua::state::raw::RawLua>>`
  --> $RUST/alloc/src/rc.rs
-  |
-  | pub struct Weak<
-  |            ^^^^
 note: required because it appears within the type `WeakLua`
  --> src/state.rs
   |
@@ -163,6 +133,3 @@ note: required because it's used within this closure
   |                  ^^^^^^^
 note: required by a bound in `std::panic::catch_unwind`
  --> $RUST/std/src/panic.rs
-  |
-  | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
-  |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`

--- a/tests/compile/scope_callback_capture.stderr
+++ b/tests/compile/scope_callback_capture.stderr
@@ -1,24 +1,24 @@
 error[E0373]: closure may outlive the current function, but it borrows `inner`, which is owned by the current function
   --> tests/compile/scope_callback_capture.rs:7:43
    |
-5  |     lua.scope(|scope| {
+ 5 |     lua.scope(|scope| {
    |                ----- has type `&'1 mlua::Scope<'1, '_>`
-6  |         let mut inner: Option<Table> = None;
-7  |         let f = scope.create_function_mut(|_, t: Table| {
+ 6 |         let mut inner: Option<Table> = None;
+ 7 |         let f = scope.create_function_mut(|_, t: Table| {
    |                                           ^^^^^^^^^^^^^ may outlive borrowed value `inner`
-8  |             inner = Some(t);
+ 8 |             inner = Some(t);
    |             ----- `inner` is borrowed here
    |
 note: function requires argument type to outlive `'1`
   --> tests/compile/scope_callback_capture.rs:7:17
    |
-7  |           let f = scope.create_function_mut(|_, t: Table| {
+ 7 |           let f = scope.create_function_mut(|_, t: Table| {
    |  _________________^
-8  | |             inner = Some(t);
-9  | |             Ok(())
+ 8 | |             inner = Some(t);
+ 9 | |             Ok(())
 10 | |         })?;
    | |__________^
 help: to force the closure to take ownership of `inner` (and any other referenced variables), use the `move` keyword
    |
-7  |         let f = scope.create_function_mut(move |_, t: Table| {
+ 7 |         let f = scope.create_function_mut(move |_, t: Table| {
    |                                           ++++

--- a/tests/compile/scope_invariance.stderr
+++ b/tests/compile/scope_invariance.stderr
@@ -1,7 +1,7 @@
 error[E0373]: closure may outlive the current function, but it borrows `test.field`, which is owned by the current function
   --> tests/compile/scope_invariance.rs:13:39
    |
-9  |     lua.scope(|scope| {
+ 9 |     lua.scope(|scope| {
    |                ----- has type `&'1 mlua::Scope<'1, '_>`
 ...
 13 |             scope.create_function_mut(|_, ()| {

--- a/tests/compile/scope_mutable_aliasing.stderr
+++ b/tests/compile/scope_mutable_aliasing.stderr
@@ -10,3 +10,9 @@ error[E0499]: cannot borrow `i` as mutable more than once at a time
    |                  argument requires that `i` is borrowed for `'1`
 12 |         let _b = scope.create_userdata(MyUserData(&mut i)).unwrap();
    |                                                   ^^^^^^ second mutable borrow occurs here
+   |
+note: requirement that the value outlives `'1` introduced here
+  --> src/scope.rs
+   |
+   |         T: UserData + 'env,
+   |                       ^^^^

--- a/tests/compile/scope_userdata_borrow.stderr
+++ b/tests/compile/scope_userdata_borrow.stderr
@@ -13,3 +13,9 @@ error[E0597]: `ibad` does not live long enough
    |             argument requires that `ibad` is borrowed for `'1`
 16 |         };
    |         - `ibad` dropped here while still borrowed
+   |
+note: requirement that the value outlives `'1` introduced here
+  --> src/scope.rs
+   |
+   |         T: UserData + 'env,
+   |                       ^^^^

--- a/tests/luau.rs
+++ b/tests/luau.rs
@@ -448,7 +448,7 @@ fn test_loadstring() -> Result<()> {
     assert_eq!(f.call::<i32>(())?, 123);
 
     let err = lua
-        .load(r#"loadstring("retur 123", "chunk")"#)
+        .load(r#"loadstring("retur 123", "chunk")"#) // spellchecker:disable-line
         .exec()
         .err()
         .unwrap();

--- a/typos.toml
+++ b/typos.toml
@@ -1,5 +1,9 @@
 [default]
 extend-ignore-identifiers-re = ["2nd", "ser"]
+# Enable inline disable comments: // spellchecker:disable-line
+extend-ignore-re = [
+    "(?Rm)^.*//\\s*spellchecker:disable-line$",
+]
 
 [default.extend-words]
 thr = "thr"


### PR DESCRIPTION
Typos workflow was failing for #660. Investigated and found three issues:
- An actual typo in `state.rs`.
- Exceptions for intended typos in tests.
- `transferrable` typo in rustc's stderr. Fixed in rustc `1.92`.

`1.92` should be the default version in github workflows mid december or so. This PR can then be merged (if all else is ok). The stderr format will need to change to this output in any case for `1.92`.