### PR TITLE
New method AnyUserData::is_proxy

### DIFF
--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -679,6 +679,14 @@ impl AnyUserData {
         matches!(type_id, Some(type_id) if type_id == TypeId::of::<T>())
     }
 
+    /// Checks whether the type of this userdata is a [proxy object] for `T`.
+    ///
+    /// [proxy object]: crate::Lua::create_proxy
+    #[inline]
+    pub fn is_proxy<T: 'static>(&self) -> bool {
+        self.is::<UserDataProxy<T>>()
+    }
+
     /// Borrow this userdata immutably if it is of type `T`.
     ///
     /// # Errors

--- a/tests/userdata.rs
+++ b/tests/userdata.rs
@@ -731,6 +731,9 @@ fn test_userdata_proxy() -> Result<()> {
     let globals = lua.globals();
     globals.set("MyUserData", lua.create_proxy::<MyUserData>()?)?;
 
+    assert!(!globals.get::<AnyUserData>("MyUserData")?.is_proxy::<()>());
+    assert!(globals.get::<AnyUserData>("MyUserData")?.is_proxy::<MyUserData>());
+
     lua.load(
         r#"
         assert(MyUserData.static_field == 123)


### PR DESCRIPTION
Make it possible to check whether an `AnyUserData` is a proxy object for type T