### PR TITLE
Expose RawLua via Lua::exec_raw_lua

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -337,6 +337,38 @@ impl Lua {
         R::from_stack_multi(nresults, &lua)
     }
 
+    /// Runs callback with the inner RawLua value. It can be used to manually push and get values on the stack.
+    ///
+    /// This function is safe because all unsafe actions with RawLua can only be done with unsafe
+    ///     
+    /// # Example
+    /// ```
+    /// # use mlua::{Lua, Result, FromLua, IntoLua};
+    /// # fn main() -> Result<()> {
+    /// let lua = Lua::new();
+    /// let n: i32 = {
+    ///     let num = 11i32;
+    ///     lua.exec_raw_lua(|lua| {
+    ///         unsafe {
+    ///             <i32 as IntoLua>::push_into_stack(num, lua)?;
+    ///         }
+    ///
+    ///         let n = unsafe {
+    ///             <i32 as FromLua>::from_stack(-1, lua)?
+    ///         };
+    ///         Result::Ok(n)
+    ///     })
+    /// }?;
+    /// assert_eq!(n, 11);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[doc(hidden)]
+    pub fn exec_raw_lua<R>(&self, f: impl FnOnce(&RawLua) -> R) -> R {
+        let lua = self.lock();
+        f(&lua)
+    }
+
     /// Loads the specified subset of the standard libraries into an existing Lua state.
     ///
     /// Use the [`StdLib`] flags to specify the libraries you want to load.


### PR DESCRIPTION
See issue #671, #215, and commit 9f0fc27. 
This PR solves the problem is a similar manner. It exposes a simple api `Lua::exec_raw_lua()`, which runs a callback, that takes a `&RawLua` as the argument. That allows usage of the unsafe methods of `FromLua` and `IntoLua` traits to interact with the stack on a lower level. Just like the previous solution, this PR's method is marked `#[doc(hidden)]`.