### PR TITLE
feat(async): export AsyncCallFuture

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ pub use crate::{
 
 #[cfg(feature = "async")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
-pub use crate::{thread::AsyncThread, traits::LuaNativeAsyncFn};
+pub use crate::{thread::AsyncThread, traits::LuaNativeAsyncFn, function::AsyncCallFuture};
 
 #[cfg(feature = "serde")]
 #[doc(inline)]


### PR DESCRIPTION
### Summary

This PR exports the `AsyncCallFuture` type from the async module.

### Motivation

While working with `mlua`’s async APIs, I needed to reference `AsyncCallFuture` from downstream code, but the type was not publicly exported. Exposing it makes it possible to use it in type signatures and integrations without duplicating or relying on internal details.

### Changes

* Export `AsyncCallFuture` so it can be used by external crates.

### Notes

This is a small, non-breaking change that does not alter existing behavior.