### PR TITLE
Expose Lua install location to dependent build scripts

### DIFF
--- a/mlua-sys/build/find_vendored.rs
+++ b/mlua-sys/build/find_vendored.rs
@@ -29,4 +29,5 @@ pub fn probe_lua() {
         .build();
 
     artifacts.print_cargo_metadata();
+    artifacts.print_cargo_root();
 }


### PR DESCRIPTION
Blocked on https://github.com/mlua-rs/lua-src-rs/pull/17

This allows downstream build scripts to read the `DEP_LUA_ROOT` env variable to access the include and lib directories built by mlua-sys