### PR TITLE
Allow `#[mlua::userdata_impl]` in a different module than the type

### DIFF
--- a/docs/UserData.md
+++ b/docs/UserData.md
@@ -57,6 +57,9 @@ Use `#[mlua::userdata_impl]` on an `impl` block to register methods,
 metamethods, and constants. All items in the block are registered automatically,
 regardless of visibility.
 
+Multiple `impl` blocks are supported and they do not need to live in the same
+module as the type definition.
+
 ## Method detection
 
 The receiver type determines how a method is registered:

--- a/mlua_derive/src/userdata/mod.rs
+++ b/mlua_derive/src/userdata/mod.rs
@@ -131,17 +131,17 @@ pub fn userdata_type(item: TokenStream) -> TokenStream {
         }
     }
 
-    let registration_type_name = format_ident!("__MluaUserDataRegistration_{type_name}");
     let register_fields_fn_name = format_ident!("__mlua_register_{type_name}_fields");
 
     let output = quote! {
-        #[doc(hidden)]
-        #[allow(non_camel_case_types)]
-        struct #registration_type_name {
-            register: fn(&mut ::mlua::userdata::UserDataRegistry<#type_name>),
+        // Registrations are collected through the type itself, so that `#[mlua::userdata_impl]`
+        // can submit them from any module.
+        impl ::mlua::userdata::UserDataRegistrar for #type_name {
+            fn inventory_registry() -> &'static ::mlua::__inventory::Registry {
+                static REGISTRY: ::mlua::__inventory::Registry = ::mlua::__inventory::Registry::new();
+                &REGISTRY
+            }
         }
-
-        ::mlua::__inventory::collect!(#registration_type_name);
 
         #[allow(non_snake_case)]
         fn #register_fields_fn_name(registry: &mut ::mlua::userdata::UserDataRegistry<#type_name>) {
@@ -150,12 +150,12 @@ pub fn userdata_type(item: TokenStream) -> TokenStream {
         }
 
         ::mlua::__inventory::submit! {
-            #registration_type_name { register: #register_fields_fn_name }
+            ::mlua::userdata::UserDataRegistration::<#type_name> { register: #register_fields_fn_name }
         }
 
         impl ::mlua::userdata::UserData for #type_name {
             fn register(registry: &mut ::mlua::userdata::UserDataRegistry<Self>) {
-                for item in ::mlua::__inventory::iter::<#registration_type_name> {
+                for item in ::mlua::__inventory::iter::<::mlua::userdata::UserDataRegistration<#type_name>> {
                     (item.register)(registry);
                 }
             }

--- a/mlua_derive/src/userdata/userdata_impl.rs
+++ b/mlua_derive/src/userdata/userdata_impl.rs
@@ -323,7 +323,6 @@ pub fn userdata_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let unique_suffix = COUNTER.fetch_add(1, Ordering::Relaxed);
     let register_fn_name = format_ident!("__mlua_register_{type_name}_{unique_suffix}");
-    let registration_type_name = format_ident!("__MluaUserDataRegistration_{type_name}");
 
     let mut registration_calls = Vec::new();
     for item in &input.items {
@@ -522,7 +521,7 @@ pub fn userdata_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         ::mlua::__inventory::submit! {
-            #registration_type_name { register: #register_fn_name }
+            ::mlua::userdata::UserDataRegistration::<#type_path> { register: #register_fn_name }
         }
 
         #input

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -33,6 +33,9 @@ pub(crate) use cell::UserDataStorage;
 pub use r#ref::{UserDataOwned, UserDataRef, UserDataRefMut};
 pub use registry::UserDataRegistry;
 pub(crate) use registry::{RawUserDataRegistry, UserDataProxy};
+#[cfg(feature = "macros")]
+#[doc(hidden)]
+pub use registry::{UserDataRegistrar, UserDataRegistration};
 pub(crate) use util::{
     TypeIdHints, borrow_userdata_scoped, borrow_userdata_scoped_mut, collect_userdata,
     init_userdata_metatable,

--- a/src/userdata/registry.rs
+++ b/src/userdata/registry.rs
@@ -677,6 +677,40 @@ lua_userdata_impl!(std::sync::Arc<parking_lot::Mutex<T>>);
 #[cfg(feature = "userdata-wrappers")]
 lua_userdata_impl!(std::sync::Arc<parking_lot::RwLock<T>>);
 
+/// A single registration function collected by the `mlua` derive macros.
+///
+/// This is not part of the public API.
+#[cfg(feature = "macros")]
+#[doc(hidden)]
+pub struct UserDataRegistration<T> {
+    pub register: fn(&mut UserDataRegistry<T>),
+}
+
+/// Links a userdata type to the inventory registry holding its registrations.
+///
+/// Implemented by `#[derive(UserData)]`, which is what allows `#[mlua::userdata_impl]` to submit
+/// registrations through the type itself rather than through a name that is only reachable from the
+/// module where the type is defined.
+///
+/// This is not part of the public API.
+#[cfg(feature = "macros")]
+#[doc(hidden)]
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is missing `#[derive(UserData)]`",
+    note = "`#[mlua::userdata_impl]` requires the type to derive `UserData`"
+)]
+pub trait UserDataRegistrar: Sized + 'static {
+    fn inventory_registry() -> &'static inventory::Registry;
+}
+
+#[cfg(feature = "macros")]
+impl<T: UserDataRegistrar> inventory::Collect for UserDataRegistration<T> {
+    #[inline]
+    fn registry() -> &'static inventory::Registry {
+        T::inventory_registry()
+    }
+}
+
 #[cfg(test)]
 mod assertions {
     #[cfg(feature = "send")]

--- a/tests/userdata_macro.rs
+++ b/tests/userdata_macro.rs
@@ -569,6 +569,53 @@ fn test_wildcard_params() {
     .unwrap();
 }
 
+// The type definition and its Lua bindings can live in different modules.
+mod counter_type {
+    use mlua::UserData;
+
+    #[derive(Clone, Debug, UserData)]
+    pub struct Counter {
+        pub count: u32,
+    }
+}
+
+mod counter_bindings {
+    use mlua::Result;
+
+    use super::counter_type::Counter;
+
+    #[mlua::userdata_impl]
+    impl Counter {
+        #[lua(infallible)]
+        fn new() -> Counter {
+            Counter { count: 0 }
+        }
+
+        fn increment(&mut self) -> Result<u32> {
+            self.count += 1;
+            Ok(self.count)
+        }
+    }
+}
+
+#[test]
+fn test_impl_in_other_module() {
+    let lua = Lua::new();
+    lua.globals()
+        .set("Counter", lua.create_proxy::<counter_type::Counter>().unwrap())
+        .unwrap();
+    lua.load(
+        r#"
+        local c = Counter.new()
+        assert(c:increment() == 1, "increment should return 1")
+        assert(c:increment() == 2, "increment should return 2")
+        assert(c.count == 2, "field registered by the derive should be visible too")
+    "#,
+    )
+    .exec()
+    .unwrap();
+}
+
 #[cfg(feature = "async")]
 mod async_tests {
     use mlua::{Lua, Result, UserData};


### PR DESCRIPTION
## The bug

`#[mlua::userdata_impl]` only compiles when the `impl` block is in the same module as
`#[derive(UserData)]`. Splitting a type from its Lua bindings — a natural layout when embedding
Lua — fails:

```rust
mod types {
    #[derive(mlua::UserData)]
    pub struct Counter {
        pub count: u32,
    }
}

mod bindings {
    use super::types::Counter;

    #[mlua::userdata_impl]
    impl Counter {
        fn increment(&mut self) -> mlua::Result<u32> {
            self.count += 1;
            Ok(self.count)
        }
    }
}
```

```
error[E0422]: cannot find struct, variant or union type `__MluaUserDataRegistration_Counter` in this scope
   --> tests/userdata_macro.rs:587:5
    |
587 |     #[mlua::userdata_impl]
    |     ^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
note: struct `crate::counter_type::__MluaUserDataRegistration_Counter` exists but is inaccessible
```

The derive emitted a private `__MluaUserDataRegistration_<Type>` struct plus an
`inventory::collect!` in the type's module, and `#[mlua::userdata_impl]` submitted to it by bare
identifier. That identifier only resolves in the module where the derive was expanded.

## The fix

Route the collection through the type itself, since the type is by definition in scope wherever the
impl block is written. `mlua` gains two `#[doc(hidden)]` items behind the `macros` feature:

```rust
pub struct UserDataRegistration<T> {
    pub register: fn(&mut UserDataRegistry<T>),
}

pub trait UserDataRegistrar: Sized + 'static {
    fn inventory_registry() -> &'static inventory::Registry;
}

impl<T: UserDataRegistrar> inventory::Collect for UserDataRegistration<T> {
    fn registry() -> &'static inventory::Registry {
        T::inventory_registry()
    }
}
```

`#[derive(UserData)]` implements `UserDataRegistrar` (holding the per-type `inventory::Registry`
that `inventory::collect!` used to create), and both macros now submit
`::mlua::userdata::UserDataRegistration::<Type> { register: ... }`. That is a fully qualified,
const-constructible struct literal, which is what `inventory::submit!` requires, and it names no
module-local item.

This is the right layer for the fix: the resolution failure is purely an artifact of how the two
macros agreed on a name, so keeping the per-type inventory registry but keying it off the type
rather than off a generated identifier removes the module coupling without changing when or how
registrations run.

A type used with `#[mlua::userdata_impl]` but no `#[derive(UserData)]` previously failed with the
same `E0422`. It now reports the missing bound, with a `#[diagnostic::on_unimplemented]` message:

```
error[E0277]: `NoDerive` is missing `#[derive(UserData)]`
 --> tests/tmp.rs:9:1
  |
9 | #[mlua::userdata_impl]
  | ^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
  |
  = note: `#[mlua::userdata_impl]` requires the type to derive `UserData`
```

## Verification

New test `test_impl_in_other_module` in `tests/userdata_macro.rs` puts the derive and the
`userdata_impl` in sibling modules and asserts that both the derive's field registration and the
impl block's methods land on the same type.

Before the fix (test applied, sources reverted):

```
error[E0422]: cannot find struct, variant or union type `__MluaUserDataRegistration_Counter` in this scope
   --> tests/userdata_macro.rs:587:5
error: could not compile `mlua` (test "userdata_macro") due to 1 previous error
```

After:

```
running 8 tests
test test_known_borrow_wrappers ... ok
test test_param_name_hygiene ... ok
test test_impl_in_other_module ... ok
test test_color ... ok
test test_point ... ok
test test_wildcard_params ... ok
test test_static_metamethods ... ok
test test_rectangle ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Full suite, `--features lua54,vendored,async,send,serde,macros`: 286 tests passed, 0 failed
(1 ignored: the `trybuild` runner), plus 48 doctests passed. The 6 pre-existing `trybuild` stderr
mismatches under `-- --ignored` are unchanged from a clean checkout of `main` (they are rustc
span-rendering differences; CI blesses them with `TRYBUILD=overwrite`).

Also checked by hand, all passing:

- `lua51`, `lua54`, `luau` test runs and a `luajit` build — the derive is Lua-version independent;
- a build with `macros` disabled, to confirm the new items are correctly feature-gated;
- type reached through a `pub use` alias from the impl block's module;
- type in a nested module, impl written as `impl crate::types::deep::Deep`;
- two `impl` blocks for one type in two different modules;
- `#[cfg]`-gated fields and methods;
- the single-module layout, which is what the existing tests in `tests/userdata_macro.rs` cover;
- registrations do not leak between types (each type keeps its own registry).

`cargo +nightly fmt -- --check` is clean and `cargo +nightly clippy` reports no new warnings.

## Not changed

- Generic types and generic `impl` blocks are still rejected by the macros, as before.
- No `CHANGELOG.md` entry, since that file looks maintainer-maintained at release time — happy to
  add one if you'd like.
