### PR TITLE
Improve conflicting Lua feature errors

### DIFF
--- a/mlua-sys/build/main.rs
+++ b/mlua-sys/build/main.rs
@@ -19,7 +19,25 @@ cfg_if::cfg_if! {
         }
     } else {
         fn main() {
-            compile_error!("You can enable only one of the features: lua55, lua54, lua53, lua52, lua51, luajit, luajit52, luau");
+            let features = [
+                (cfg!(feature = "lua55"), "lua55"),
+                (cfg!(feature = "lua54"), "lua54"),
+                (cfg!(feature = "lua53"), "lua53"),
+                (cfg!(feature = "lua52"), "lua52"),
+                (cfg!(feature = "lua51"), "lua51"),
+                (cfg!(feature = "luajit52"), "luajit52"),
+                (
+                    cfg!(all(feature = "luajit", not(feature = "luajit52"))),
+                    "luajit",
+                ),
+                (cfg!(feature = "luau"), "luau"),
+            ]
+            .into_iter()
+            .filter_map(|(enabled, feature)| enabled.then_some(feature))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+            println!("cargo::error=You enabled {features}; only one Lua feature can be enabled");
         }
     }
 }


### PR DESCRIPTION
## Summary

- report the Lua runtime features that are actually enabled when they conflict
- keep `luajit52` concise instead of also listing its implied `luajit` feature
- preserve the existing single-feature and no-feature behavior

## Verification

- `cargo check -p mlua-sys --features lua51,lua54 --offline` (expected failure names both features)
- `cargo check -p mlua-sys --features lua55,lua53,luau --offline` (expected failure names all three features)
- `cargo check -p mlua-sys --features lua54,luajit52 --offline` (expected failure names `luajit52` once)
- `cargo check -p mlua-sys --features lua54,vendored --offline`
- `cargo test --features lua54,vendored --offline`
- `cargo clippy -p mlua-sys --all-targets --features lua54,vendored --offline -- -D warnings`
- `rustfmt --edition 2024 --check mlua-sys/build/main.rs`

Closes #729