### PR TITLE
Clippy fixes

### DIFF
--- a/examples/async_http_client.rs
+++ b/examples/async_http_client.rs
@@ -14,9 +14,10 @@ impl UserData for BodyReader {
         // Every call returns a next chunk
         methods.add_async_method_mut("read", |lua, mut reader, ()| async move {
             if let Some(bytes) = reader.0.frame().await
-                && let Some(bytes) = bytes.into_lua_err()?.data_ref() {
-                    return Some(lua.create_string(bytes)).transpose();
-                }
+                && let Some(bytes) = bytes.into_lua_err()?.data_ref()
+            {
+                return Some(lua.create_string(bytes)).transpose();
+            }
             Ok(None)
         });
     }

--- a/examples/async_http_client.rs
+++ b/examples/async_http_client.rs
@@ -13,11 +13,10 @@ impl UserData for BodyReader {
     fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
         // Every call returns a next chunk
         methods.add_async_method_mut("read", |lua, mut reader, ()| async move {
-            if let Some(bytes) = reader.0.frame().await {
-                if let Some(bytes) = bytes.into_lua_err()?.data_ref() {
-                    return Some(lua.create_string(&bytes)).transpose();
+            if let Some(bytes) = reader.0.frame().await
+                && let Some(bytes) = bytes.into_lua_err()?.data_ref() {
+                    return Some(lua.create_string(bytes)).transpose();
                 }
-            }
             Ok(None)
         });
     }

--- a/examples/guided_tour.rs
+++ b/examples/guided_tour.rs
@@ -35,7 +35,7 @@ fn main() -> Result<()> {
     assert_eq!(globals.get::<String>("global")?, "foobar");
 
     assert_eq!(lua.load("1 + 1").eval::<i32>()?, 2);
-    assert_eq!(lua.load("false == false").eval::<bool>()?, true);
+    assert!(lua.load("false == false").eval::<bool>()?);
     assert_eq!(lua.load("return 1 + 2").eval::<i32>()?, 3);
 
     // Use can use special `chunk!` macro to use Rust tokenizer and automatically capture variables
@@ -119,15 +119,13 @@ fn main() -> Result<()> {
     })?;
     globals.set("join", join)?;
 
-    assert_eq!(
+    assert!(
         lua.load(r#"check_equal({"a", "b", "c"}, {"a", "b", "c"})"#)
-            .eval::<bool>()?,
-        true
+            .eval::<bool>()?
     );
-    assert_eq!(
-        lua.load(r#"check_equal({"a", "b", "c"}, {"d", "e", "f"})"#)
-            .eval::<bool>()?,
-        false
+    assert!(
+        !lua.load(r#"check_equal({"a", "b", "c"}, {"d", "e", "f"})"#)
+            .eval::<bool>()?
     );
     assert_eq!(lua.load(r#"join("a", "b", "c")"#).eval::<String>()?, "abc");
 

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -20,7 +20,7 @@ fn main() {
             match lua.load(&line).eval::<MultiValue>() {
                 Ok(values) => {
                     editor.add_history_entry(line).unwrap();
-                    if values.len() > 0 {
+                    if !values.is_empty() {
                         println!(
                             "{}",
                             values
@@ -37,7 +37,7 @@ fn main() {
                     ..
                 }) => {
                     // continue reading input and append it to `line`
-                    line.push_str("\n"); // separate input lines
+                    line.push('\n'); // separate input lines
                     prompt = ">> ";
                 }
                 Err(e) => {

--- a/src/state/raw.rs
+++ b/src/state/raw.rs
@@ -401,11 +401,10 @@ impl RawLua {
             },
         );
         #[cfg(feature = "luau-jit")]
-        if status == ffi::LUA_OK {
-            if (*self.extra.get()).enable_jit && ffi::luau_codegen_supported() != 0 {
+        if status == ffi::LUA_OK
+            && (*self.extra.get()).enable_jit && ffi::luau_codegen_supported() != 0 {
                 ffi::luau_codegen_compile(state, -1);
             }
-        }
         status
     }
 

--- a/src/state/raw.rs
+++ b/src/state/raw.rs
@@ -401,10 +401,9 @@ impl RawLua {
             },
         );
         #[cfg(feature = "luau-jit")]
-        if status == ffi::LUA_OK
-            && (*self.extra.get()).enable_jit && ffi::luau_codegen_supported() != 0 {
-                ffi::luau_codegen_compile(state, -1);
-            }
+        if status == ffi::LUA_OK && (*self.extra.get()).enable_jit && ffi::luau_codegen_supported() != 0 {
+            ffi::luau_codegen_compile(state, -1);
+        }
         status
     }
 

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -120,7 +120,7 @@ async fn test_async_call() -> Result<()> {
     assert_eq!(hello.call_async::<String>("alex").await?, "hello, alex!");
 
     // Executing non-async functions using async call is allowed
-    let sum = lua.create_function(|_lua, (a, b): (i64, i64)| return Ok(a + b))?;
+    let sum = lua.create_function(|_lua, (a, b): (i64, i64)| Ok(a + b))?;
     assert_eq!(sum.call_async::<i64>((5, 1)).await?, 6);
 
     Ok(())
@@ -230,7 +230,7 @@ async fn test_async_return_async_closure() -> Result<()> {
 
         let g = lua.create_async_function(move |_, b: i64| async move {
             sleep_ms(10).await;
-            return Ok(a + b);
+            Ok(a + b)
         })?;
 
         Ok(g)

--- a/tests/buffer.rs
+++ b/tests/buffer.rs
@@ -25,7 +25,7 @@ fn test_buffer() -> Result<()> {
 
     // Check that we can pass buffer type to Lua
     let buf1 = buf1.as_buffer().unwrap();
-    let func = lua.create_function(|_, buf: Value| return buf.to_string())?;
+    let func = lua.create_function(|_, buf: Value| buf.to_string())?;
     assert!(func.call::<String>(buf1)?.starts_with("buffer:"));
 
     // Check buffer methods

--- a/tests/chunk.rs
+++ b/tests/chunk.rs
@@ -50,7 +50,7 @@ fn test_chunk_path() -> Result<()> {
 
     // &Path
     assert_eq!(
-        (lua.load(&*temp_dir.path().join("module.lua").as_path())).eval::<i32>()?,
+        (lua.load(temp_dir.path().join("module.lua").as_path())).eval::<i32>()?,
         321
     );
 
@@ -63,14 +63,14 @@ fn test_chunk_impls() -> Result<()> {
 
     // StdString
     assert_eq!(lua.load(String::from("1")).eval::<i32>()?, 1);
-    assert_eq!(lua.load(&String::from("2")).eval::<i32>()?, 2);
+    assert_eq!(lua.load(String::from("2")).eval::<i32>()?, 2);
 
     // &[u8]
     assert_eq!(lua.load(&b"3"[..]).eval::<i32>()?, 3);
 
     // Vec<u8>
     assert_eq!(lua.load(b"4".to_vec()).eval::<i32>()?, 4);
-    assert_eq!(lua.load(&b"5".to_vec()).eval::<i32>()?, 5);
+    assert_eq!(lua.load(b"5".to_vec()).eval::<i32>()?, 5);
 
     Ok(())
 }
@@ -172,7 +172,7 @@ fn test_compiler_library_constants() {
     let lua = Lua::new();
     lua.set_compiler(compiler);
     let const_bool = lua.load("return mylib.const_bool").eval::<bool>().unwrap();
-    assert_eq!(const_bool, true);
+    assert!(const_bool);
     let const_num = lua.load("return mylib.const_num").eval::<f64>().unwrap();
     assert_eq!(const_num, 123.0);
     let const_vec = lua.load("return mylib.const_vec").eval::<Vector>().unwrap();

--- a/tests/conversion.rs
+++ b/tests/conversion.rs
@@ -313,7 +313,7 @@ fn test_bool_into_lua() -> Result<()> {
     // Push into stack
     let table = lua.create_table()?;
     table.set("b", true)?;
-    assert_eq!(true, table.get::<bool>("b")?);
+    assert!(table.get::<bool>("b")?);
 
     Ok(())
 }

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -33,7 +33,7 @@ fn test_error_context() -> Result<()> {
 
     // Rewrite context message and test `downcast_ref`
     let func3 = lua.create_function(|_, ()| {
-        Err::<(), _>(Error::external(io::Error::new(io::ErrorKind::Other, "other")))
+        Err::<(), _>(Error::external(io::Error::other("other")))
             .context("some context")
             .context("some new context")
     })?;
@@ -52,11 +52,11 @@ fn test_error_chain() -> Result<()> {
     let lua = Lua::new();
 
     // Check that `Error::ExternalError` creates a chain with a single element
-    let io_err = io::Error::new(io::ErrorKind::Other, "other");
+    let io_err = io::Error::other("other");
     assert_eq!(Error::external(io_err).chain().count(), 1);
 
     let func = lua.create_function(|_, ()| {
-        let err = Error::external(io::Error::new(io::ErrorKind::Other, "other")).context("io error");
+        let err = Error::external(io::Error::other("other")).context("io error");
         Err::<(), _>(err)
     })?;
     let err = func.call::<()>(()).unwrap_err();

--- a/tests/function.rs
+++ b/tests/function.rs
@@ -213,7 +213,7 @@ fn test_function_info() -> Result<()> {
         let func_with_upvalues_info = func_with_upvalues.info();
         assert_eq!(func_with_upvalues_info.num_upvalues, 2);
         assert_eq!(func_with_upvalues_info.num_params, 1);
-        assert_eq!(func_with_upvalues_info.is_vararg, true);
+        assert!(func_with_upvalues_info.is_vararg);
     }
 
     Ok(())
@@ -227,7 +227,7 @@ fn test_function_dump() -> Result<()> {
     let concat_lua = lua
         .load(r#"function(arg1, arg2) return arg1 .. arg2 end"#)
         .eval::<Function>()?;
-    let concat = lua.load(&concat_lua.dump(false)).into_function()?;
+    let concat = lua.load(concat_lua.dump(false)).into_function()?;
 
     assert_eq!(concat.call::<String>(("foo", "bar"))?, "foobar");
 
@@ -417,7 +417,7 @@ fn test_function_wrap() -> Result<()> {
     // Check recursive mut callback error
     let fmut = Function::wrap_mut(|f: Function| match f.call::<()>(&f) {
         Err(Error::CallbackError { cause, .. }) => match cause.as_ref() {
-            Error::RecursiveMutCallback { .. } => Ok::<_, Error>(()),
+            Error::RecursiveMutCallback => Ok::<_, Error>(()),
             other => panic!("incorrect result: {other:?}"),
         },
         other => panic!("incorrect result: {other:?}"),

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -86,7 +86,7 @@ fn test_multivalue_by_ref() -> Result<()> {
     let f = lua.create_function(|_, (i, s, b): (i32, LuaString, bool)| {
         assert_eq!(i, 3);
         assert_eq!(s.to_str()?, "hello");
-        assert_eq!(b, true);
+        assert!(b);
         Ok(())
     })?;
     f.call::<()>(&multi)?;

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -109,22 +109,13 @@ fn test_serialize_failure() -> Result<(), Box<dyn StdError>> {
     let lua = Lua::new();
 
     let ud = Value::UserData(lua.create_userdata(MyUserData(123))?);
-    match serde_json::to_value(&ud) {
-        Ok(v) => panic!("expected serialization error, got {}", v),
-        Err(serde_json::Error { .. }) => {}
-    }
+    if let Ok(v) = serde_json::to_value(&ud) { panic!("expected serialization error, got {}", v) }
 
     let func = lua.create_function(|_, _: ()| Ok(()))?;
-    match serde_json::to_value(&Value::Function(func.clone())) {
-        Ok(v) => panic!("expected serialization error, got {}", v),
-        Err(serde_json::Error { .. }) => {}
-    }
+    if let Ok(v) = serde_json::to_value(Value::Function(func.clone())) { panic!("expected serialization error, got {}", v) }
 
     let thr = lua.create_thread(func)?;
-    match serde_json::to_value(&Value::Thread(thr)) {
-        Ok(v) => panic!("expected serialization error, got {}", v),
-        Err(serde_json::Error { .. }) => {}
-    }
+    if let Ok(v) = serde_json::to_value(Value::Thread(thr)) { panic!("expected serialization error, got {}", v) }
 
     Ok(())
 }
@@ -822,12 +813,12 @@ fn test_arbitrary_precision() {
 fn test_buffer_serialize() -> LuaResult<()> {
     let lua = Lua::new();
 
-    let buf = lua.create_buffer(&[1, 2, 3, 4])?;
+    let buf = lua.create_buffer([1, 2, 3, 4])?;
     let val = serde_value::to_value(&buf).unwrap();
     assert_eq!(val, serde_value::Value::Bytes(vec![1, 2, 3, 4]));
 
     // Try empty buffer
-    let buf = lua.create_buffer(&[])?;
+    let buf = lua.create_buffer([])?;
     let val = serde_value::to_value(&buf).unwrap();
     assert_eq!(val, serde_value::Value::Bytes(vec![]));
 
@@ -839,7 +830,7 @@ fn test_buffer_serialize() -> LuaResult<()> {
 fn test_buffer_from_value() -> LuaResult<()> {
     let lua = Lua::new();
 
-    let buf = lua.create_buffer(&[1, 2, 3, 4])?;
+    let buf = lua.create_buffer([1, 2, 3, 4])?;
     let val = lua.from_value::<serde_value::Value>(Value::Buffer(buf)).unwrap();
     assert_eq!(val, serde_value::Value::Bytes(vec![1, 2, 3, 4]));
 

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -109,13 +109,19 @@ fn test_serialize_failure() -> Result<(), Box<dyn StdError>> {
     let lua = Lua::new();
 
     let ud = Value::UserData(lua.create_userdata(MyUserData(123))?);
-    if let Ok(v) = serde_json::to_value(&ud) { panic!("expected serialization error, got {}", v) }
+    if let Ok(v) = serde_json::to_value(&ud) {
+        panic!("expected serialization error, got {}", v)
+    }
 
     let func = lua.create_function(|_, _: ()| Ok(()))?;
-    if let Ok(v) = serde_json::to_value(Value::Function(func.clone())) { panic!("expected serialization error, got {}", v) }
+    if let Ok(v) = serde_json::to_value(Value::Function(func.clone())) {
+        panic!("expected serialization error, got {}", v)
+    }
 
     let thr = lua.create_thread(func)?;
-    if let Ok(v) = serde_json::to_value(Value::Thread(thr)) { panic!("expected serialization error, got {}", v) }
+    if let Ok(v) = serde_json::to_value(Value::Thread(thr)) {
+        panic!("expected serialization error, got {}", v)
+    }
 
     Ok(())
 }

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -74,7 +74,7 @@ fn test_string_views() -> Result<()> {
 fn test_string_from_bytes() -> Result<()> {
     let lua = Lua::new();
 
-    let rs = lua.create_string(&[0, 1, 2, 3, 0, 1, 2, 3])?;
+    let rs = lua.create_string([0, 1, 2, 3, 0, 1, 2, 3])?;
     assert_eq!(rs.as_bytes(), &[0, 1, 2, 3, 0, 1, 2, 3]);
 
     Ok(())

--- a/tests/table.rs
+++ b/tests/table.rs
@@ -297,7 +297,8 @@ fn test_table_for_each() -> Result<()> {
             table.set(k, Value::Nil)?;
             lua.gc_collect()?;
         }
-        Ok(i += 1)
+        let _: () = i += 1;
+        Ok(())
     })?;
     assert_eq!(i, 5);
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -134,7 +134,7 @@ fn test_eval() -> Result<()> {
     let lua = Lua::new();
 
     assert_eq!(lua.load("\t1 + 1").eval::<i32>()?, 2);
-    assert_eq!(lua.load("false == false").eval::<bool>()?, true);
+    assert!(lua.load("false == false").eval::<bool>()?);
     assert_eq!(lua.load("\nreturn 1 + 2").eval::<i32>()?, 3);
     match lua.load("if true then").eval::<()>() {
         Err(Error::SyntaxError {
@@ -437,7 +437,7 @@ fn test_panic() -> Result<()> {
     // Test returning Rust panic (must be resumed)
     {
         let lua = make_lua(LuaOptions::default())?;
-        match catch_unwind(AssertUnwindSafe(|| -> Result<()> {
+        if let Ok(_) = catch_unwind(AssertUnwindSafe(|| -> Result<()> {
             let _caught_panic = lua
                 .load(
                     r#"
@@ -448,10 +448,7 @@ fn test_panic() -> Result<()> {
                 )
                 .eval::<Value>()?;
             Ok(())
-        })) {
-            Ok(_) => panic!("no panic was detected"),
-            Err(_) => {}
-        };
+        })) { panic!("no panic was detected") };
 
         assert!(lua.globals().get::<Value>("err")? == Value::Nil);
         match lua.load("tostring(err)").exec() {
@@ -671,10 +668,10 @@ fn test_pcall_xpcall() -> Result<()> {
     )
     .exec()?;
 
-    assert_eq!(globals.get::<bool>("pcall_status")?, false);
+    assert!(!globals.get::<bool>("pcall_status")?);
     assert_eq!(globals.get::<String>("pcall_error")?, "testerror");
 
-    assert_eq!(globals.get::<bool>("xpcall_statusr")?, false);
+    assert!(!globals.get::<bool>("xpcall_statusr")?);
     #[cfg(any(
         feature = "lua55",
         feature = "lua54",
@@ -728,7 +725,7 @@ fn test_recursive_mut_callback_error() -> Result<()> {
     match lua.globals().get::<Function>("f")?.call::<()>(false) {
         Err(Error::CallbackError { ref cause, .. }) => match *cause.as_ref() {
             Error::CallbackError { ref cause, .. } => match *cause.as_ref() {
-                Error::RecursiveMutCallback { .. } => {}
+                Error::RecursiveMutCallback => {}
                 ref other => panic!("incorrect result: {:?}", other),
             },
             ref other => panic!("incorrect result: {:?}", other),
@@ -920,14 +917,8 @@ fn test_application_data() -> Result<()> {
 
     // Insert of new data or removal should fail now
     assert!(lua.try_set_app_data::<i32>(123).is_err());
-    match catch_unwind(AssertUnwindSafe(|| lua.set_app_data::<i32>(123))) {
-        Ok(_) => panic!("expected panic"),
-        Err(_) => {}
-    }
-    match catch_unwind(AssertUnwindSafe(|| lua.remove_app_data::<i32>())) {
-        Ok(_) => panic!("expected panic"),
-        Err(_) => {}
-    }
+    if catch_unwind(AssertUnwindSafe(|| lua.set_app_data::<i32>(123))).is_ok() { panic!("expected panic") }
+    if catch_unwind(AssertUnwindSafe(|| lua.remove_app_data::<i32>())).is_ok() { panic!("expected panic") }
 
     // Check display and debug impls
     assert_eq!(format!("{s}"), "test1");
@@ -935,10 +926,7 @@ fn test_application_data() -> Result<()> {
 
     // Borrowing immutably and mutably of the same type is not allowed
     assert!(lua.try_app_data_mut::<&str>().is_err());
-    match catch_unwind(AssertUnwindSafe(|| lua.app_data_mut::<&str>().unwrap())) {
-        Ok(_) => panic!("expected panic"),
-        Err(_) => {}
-    }
+    if let Ok(_) = catch_unwind(AssertUnwindSafe(|| lua.app_data_mut::<&str>().unwrap())) { panic!("expected panic") }
     assert!(lua.try_app_data_ref::<Vec<&str>>().is_err());
     drop((s, v));
 
@@ -959,7 +947,7 @@ fn test_application_data() -> Result<()> {
     assert_eq!(*lua.app_data_ref::<Vec<&str>>().unwrap(), vec!["test2", "test3"]);
 
     lua.remove_app_data::<Vec<&str>>();
-    assert!(matches!(lua.app_data_ref::<Vec<&str>>(), None));
+    assert!(lua.app_data_ref::<Vec<&str>>().is_none());
 
     Ok(())
 }
@@ -1004,7 +992,7 @@ fn test_c_function() -> Result<()> {
 
     let func = unsafe { lua.create_c_function(c_function)? };
     func.call::<()>(())?;
-    assert_eq!(lua.globals().get::<bool>("c_function")?, true);
+    assert!(lua.globals().get::<bool>("c_function")?);
 
     Ok(())
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -448,7 +448,9 @@ fn test_panic() -> Result<()> {
                 )
                 .eval::<Value>()?;
             Ok(())
-        })) { panic!("no panic was detected") };
+        })) {
+            panic!("no panic was detected")
+        };
 
         assert!(lua.globals().get::<Value>("err")? == Value::Nil);
         match lua.load("tostring(err)").exec() {
@@ -917,8 +919,12 @@ fn test_application_data() -> Result<()> {
 
     // Insert of new data or removal should fail now
     assert!(lua.try_set_app_data::<i32>(123).is_err());
-    if catch_unwind(AssertUnwindSafe(|| lua.set_app_data::<i32>(123))).is_ok() { panic!("expected panic") }
-    if catch_unwind(AssertUnwindSafe(|| lua.remove_app_data::<i32>())).is_ok() { panic!("expected panic") }
+    if catch_unwind(AssertUnwindSafe(|| lua.set_app_data::<i32>(123))).is_ok() {
+        panic!("expected panic")
+    }
+    if catch_unwind(AssertUnwindSafe(|| lua.remove_app_data::<i32>())).is_ok() {
+        panic!("expected panic")
+    }
 
     // Check display and debug impls
     assert_eq!(format!("{s}"), "test1");
@@ -926,7 +932,9 @@ fn test_application_data() -> Result<()> {
 
     // Borrowing immutably and mutably of the same type is not allowed
     assert!(lua.try_app_data_mut::<&str>().is_err());
-    if let Ok(_) = catch_unwind(AssertUnwindSafe(|| lua.app_data_mut::<&str>().unwrap())) { panic!("expected panic") }
+    if let Ok(_) = catch_unwind(AssertUnwindSafe(|| lua.app_data_mut::<&str>().unwrap())) {
+        panic!("expected panic")
+    }
     assert!(lua.try_app_data_ref::<Vec<&str>>().is_err());
     drop((s, v));
 

--- a/tests/userdata.rs
+++ b/tests/userdata.rs
@@ -151,9 +151,9 @@ fn test_metamethods() -> Result<()> {
                     if i <= data.0 {
                         return Ok(mlua::Variadic::from_iter(vec![i, i]));
                     }
-                    return Ok(mlua::Variadic::new());
+                    Ok(mlua::Variadic::new())
                 })?;
-                Ok((stateless_iter, data.clone(), 0))
+                Ok((stateless_iter, *data, 0))
             });
         }
     }

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -76,11 +76,11 @@ fn test_value_eq() -> Result<()> {
 fn test_multi_value() {
     let mut multi_value = MultiValue::new();
     assert_eq!(multi_value.len(), 0);
-    assert_eq!(multi_value.get(0), None);
+    assert_eq!(multi_value.front(), None);
 
     multi_value.push_front(Value::Number(2.));
     multi_value.push_front(Value::Number(1.));
-    assert_eq!(multi_value.get(0), Some(&Value::Number(1.)));
+    assert_eq!(multi_value.front(), Some(&Value::Number(1.)));
     assert_eq!(multi_value.get(1), Some(&Value::Number(2.)));
 
     assert_eq!(multi_value.pop_front(), Some(Value::Number(1.)));
@@ -137,7 +137,7 @@ fn test_value_to_string() -> Result<()> {
     assert_eq!(Value::NULL.to_string()?, "null");
     assert_eq!(Value::NULL.type_name(), "lightuserdata");
     assert_eq!(
-        Value::LightUserData(LightUserData(0x1 as *const c_void as *mut _)).to_string()?,
+        Value::LightUserData(LightUserData(std::ptr::dangling::<c_void>() as *mut _)).to_string()?,
         "lightuserdata: 0x1"
     );
     assert_eq!(Value::Integer(1).to_string()?, "1");


### PR DESCRIPTION
Fix various clippy complaints.
No manual changes, these were all done by `--fix`.

If there's disagreement with any of the style changes (e.g. `.front()` vs `.get(0)`) let me know and I'm happy to apply the specific Clippy exceptions.

## Commands

```shell
for runtime in \
    lua55 lua54 lua53 lua52 lua51 \
    luajit luajit52 \
    luau luau-jit luau-vector4 \
    luau-jit,luau-vector4
do
    cargo clippy --fix --allow-dirty --all-targets -j 1 \
        --no-default-features \
        --features "$runtime,vendored,async,send,serde,macros,anyhow,userdata-wrappers,serialize"
done

for runtime in \
    lua55 lua54 lua53 lua52 lua51 \
    luajit luajit52
do
    cargo clippy --fix --allow-dirty --all-targets -j 1 \
        --no-default-features \
        --features "$runtime,vendored,async,serde,macros,anyhow,userdata-wrappers,serialize"
done

cargo +nightly fmt
```